### PR TITLE
Respect markup nested in `<stanza>` elements

### DIFF
--- a/fb2.js
+++ b/fb2.js
@@ -38,7 +38,8 @@ const POEM = {
     'subtitle': ['h2', STYLE],
     'text-author': ['p', STYLE],
     'date': ['p', STYLE],
-    'stanza': 'stanza',
+    'stanza': ['div', 'self'],
+    'v': ['div', STYLE],
 }
 
 const SECTION = {
@@ -101,22 +102,6 @@ class FB2Converter {
         el.setAttribute('href', node.getAttributeNS(NS.XLINK, 'href'))
         if (node.getAttribute('type') === 'note')
             el.setAttributeNS(NS.EPUB, 'epub:type', 'noteref')
-        return el
-    }
-    stanza(node) {
-        const el = this.convert(node, {
-            'stanza': ['p', {
-                'title': ['header', {
-                    'p': ['strong', STYLE],
-                    'empty-line': ['br'],
-                }],
-                'subtitle': ['p', STYLE],
-            }],
-        })
-        for (const child of node.children) if (child.nodeName === 'v') {
-            el.append(this.doc.createTextNode(child.textContent))
-            el.append(this.doc.createElement('br'))
-        }
         return el
     }
     convert(node, def) {
@@ -195,7 +180,7 @@ p {
 :not(p) + p, p:first-child {
     text-indent: 0;
 }
-.poem p {
+.stanza {
     text-indent: 0;
     margin: 1em 0;
 }


### PR DESCRIPTION
The original goal was to fix footnote links inside poems but the change also affects other elements nested in `<stanza>` such as `<strong>`, `<emphasis>`, etc.

Before, any verse (`<v>`) inside the stanza was converted to plain text with `.textContent` discarding any other nested elements. For example,

The following FB2 poem (only important/related code)

```xml
<title>
 <p>title</p>
</title>
<poem>
 <stanza>
  <v>first verse</v>
  <v>verse with footnote<a l:href="#n1" type="note">[1]</a></v>
  <v>etc...</v>
 </stanza>
</poem>
```

would convert into

```xml
<header xmlns="http://www.w3.org/1999/xhtml" class="title">
 <h1 class="p">title</h1>
</header>
<blockquote xmlns="http://www.w3.org/1999/xhtml" class="poem">
 <p class="stanza">
   first verse<br />
   verse with footnote[1]<br />
   etc...<br />
 </p>
</blockquote>
```

Now it converts into

```xml
<header xmlns="http://www.w3.org/1999/xhtml" class="title">
 <h1 class="p">title</h1>
</header>
<blockquote xmlns="http://www.w3.org/1999/xhtml" class="poem">
 <div class="stanza">
  <div class="v">first verse</div>
  <div class="v">verse with footnote<a class="a" href="#n1" epub:type="noteref" xmlns:epub="http://www.idpf.org/2007/ops">[1]</a></div>
  <div class="v">etc...</div>
 </div>
</blockquote>
```