### PR TITLE
TTS: improve abbreviations processing

### DIFF
--- a/tts.js
+++ b/tts.js
@@ -31,25 +31,23 @@ const getSegmenter = (lang = 'en', granularity = 'word') => {
         let sum = 0
         const rawSegments = Array.from(segmenter.segment(str))
         const mergedSegments = []
-        for (let i = 0; i < rawSegments.length; i++) {
+        for (let i = 0, j = 0; i < rawSegments.length; i++) {
             const current = rawSegments[i]
-            const next = rawSegments[i + 1]
-            const segment = current.segment.trim()
-            const nextSegment = next?.segment?.trim()
-            const endsWithAbbr = /(?:^|\s)([A-Z][a-z]{1,5})\.$/.test(segment)
-            const nextStartsWithCapital = /^[A-Z]/.test(nextSegment || '')
-            if ((endsWithAbbr && nextStartsWithCapital) || segment.length <= 3) {
+            const segment = ' ' + current.segment
+            const endsWithAbbr = /\s([A-Z]{1,2}[a-z]{0,5}|[a-z]{1,3})\.\s*$/.test(segment)
+            if (!endsWithAbbr || i >= (rawSegments.length-1)) {
                 const mergedSegment = {
-                    index: current.index,
-                    segment: current.segment + (next?.segment || ''),
-                    isWordLike: true,
+                    index: rawSegments[j].index,
+                    segment: '',
+                    isWordLike: (i == j) ? current.isWordLike : true,
+                }
+                while (j <= i) {
+                    mergedSegment.segment += rawSegments[j++].segment
                 }
                 mergedSegments.push(mergedSegment)
-                i++
-            } else {
-                mergedSegments.push(current)
             }
         }
+
         for (const { index, segment, isWordLike } of mergedSegments) {
             if (granularityIsWord && !isWordLike) continue
             while (sum <= index) sum += strs[++strIndex].length


### PR DESCRIPTION
The current implementation of _foliate-js_ TTS attempts to address the issue of abbreviations by merging raw segments according to an algorithm that is far too primitive. Indeed, it fails miserabily with this type of English sentence (which should be correctly understood and pronounced by _edge-tts_) :  `“Sir Edward R. G. Heath was born Sun. 9th of Jul. 1916.”` Actually, this sentence is very badly pronounced, with large pauses between segments.

One might think that this type of example is rarely encountered, but in French we very often find sentences such as :  `« Il alla visiter M. Martin qui habitait au 3 av. des Champs-Élysées. »`



The following proposal implements a broader algorithm with the following properties:

 1. A segment is merged with the next one if it ends with a word consisting of either:

    - one or two uppercase letters followed by zero to five lowercase letters, ending with a period. Examples: "Apr.", "Arch.", "Dept.", "Domest.", "M. Dupont", "MM. Durand et Dupond", "C. S. Lewis".

    - one to three lowercase letters ending with a period. Examples: "fem." (feminine), "p. 123" (page), art." (article).
 2. Several consecutive segments may be merged.

<ins>Note</ins>: The limits described above (2 uppercase letters, 5 or 3 lowercase letters) are arbitrary. They allow the majority of cases to be processed at a reasonable cost.