### PR TITLE
Fix phantom subchapter entry when fragment-only children share a file

### DIFF
--- a/epub.js
+++ b/epub.js
@@ -1178,11 +1178,9 @@ ${doc.querySelector('parsererror').innerText}`)
             const newSubitems = []
 
             for (const [sectionId, subitems] of groupedBySection.entries()) {
-                const groupedItem = subitems.length === 1
-                    ? subitems[0]  // Single item, keep as-is
-                    : createGroupedItem(sectionId, subitems)  // Multiple items, group them
-
-                newSubitems.push(groupedItem)
+                for (const subitem of subitems) {
+                    newSubitems.push(subitem)
+                }
             }
 
             item.subitems = newSubitems

--- a/epub.js
+++ b/epub.js
@@ -1178,9 +1178,15 @@ ${doc.querySelector('parsererror').innerText}`)
             const newSubitems = []
 
             for (const [sectionId, subitems] of groupedBySection.entries()) {
-                for (const subitem of subitems) {
-                    newSubitems.push(subitem)
+                if (item.href === sectionId) {
+                    newSubitems.push(...subitems)
+                    continue
                 }
+                const groupedItem = subitems.length === 1
+                    ? subitems[0]  // Single item, keep as-is
+                    : createGroupedItem(sectionId, subitems)  // Multiple items, group them
+
+                newSubitems.push(groupedItem)
             }
 
             item.subitems = newSubitems


### PR DESCRIPTION
When all subitems of a TOC entry pointed to the same file but different fragment anchors (e.g. `chapter.html#section1`, `chapter.html#section2`), `#groupTocSubitems` would find no natural parent among them and create a "phantom" one with a bare href (`chapter.html`, no fragment). This caused a duplicate subchapter entry to appear in the table of contents, with the remaining subchapters nested under it as children.

The fix removes the phantom parent creation. When no natural parent exists among the grouped subitems, they are now kept flat, matching the original nav.xhtml structure.

## Testing

I'm attaching an ebook ([test_ebook.zip](https://github.com/user-attachments/files/25560319/test_ebook.zip)) to reproduce the issue and verify the fix. It's working fine on my end:
<img width="578" height="830" alt="delete_before" src="https://github.com/user-attachments/assets/d2fac182-1322-41e3-a5ef-0de864bc04ec" />
(Note the dual entry for the "Anayst" chapter on the Before side.)


Also tested against a second ebook whose subchapters were already rendering correctly before this fix. Its TOC structure is unaffected by this change.

