### PR TITLE
Fix incorrect grouping of some subchapters

### DIFF
--- a/epub.js
+++ b/epub.js
@@ -1177,27 +1177,27 @@ ${doc.querySelector('parsererror').innerText}`)
             const groupedBySection = groupBySection(item.subitems)
             const newSubitems = []
 
-        for (const [sectionId, subitems] of groupedBySection.entries()) {
-            if (item.href === sectionId) {
-                // Parent already covers this section, keep subitems flat
-                newSubitems.push(...subitems)
-                continue
-            }
-            if (subitems.length === 1) {
-                // Single item, keep as-is
-                newSubitems.push(subitems[0])
-            } else {
-                const { parent, fragments } = separateParentAndFragments(sectionId, subitems)
-                if (parent) {
-                    // Natural parent exists, group fragment items under it
-                    parent.subitems = fragments.length > 0 ? fragments : parent.subitems
-                    newSubitems.push(parent)
-                } else {
-                    // No natural parent among subitems, keep them flat
+            for (const [sectionId, subitems] of groupedBySection.entries()) {
+                if (item.href === sectionId) {
+                    // Parent already covers this section, keep subitems flat
                     newSubitems.push(...subitems)
+                    continue
+                }
+                if (subitems.length === 1) {
+                    // Single item, keep as-is
+                    newSubitems.push(subitems[0])
+                } else {
+                    const { parent, fragments } = separateParentAndFragments(sectionId, subitems)
+                    if (parent) {
+                        // Natural parent exists, group fragment items under it
+                        parent.subitems = fragments.length > 0 ? fragments : parent.subitems
+                        newSubitems.push(parent)
+                    } else {
+                        // No natural parent among subitems, keep them flat
+                        newSubitems.push(...subitems)
+                    }
                 }
             }
-        }
 
             item.subitems = newSubitems
         }

--- a/epub.js
+++ b/epub.js
@@ -1177,17 +1177,27 @@ ${doc.querySelector('parsererror').innerText}`)
             const groupedBySection = groupBySection(item.subitems)
             const newSubitems = []
 
-            for (const [sectionId, subitems] of groupedBySection.entries()) {
-                if (item.href === sectionId) {
-                    newSubitems.push(...subitems)
-                    continue
-                }
-                const groupedItem = subitems.length === 1
-                    ? subitems[0]  // Single item, keep as-is
-                    : createGroupedItem(sectionId, subitems)  // Multiple items, group them
-
-                newSubitems.push(groupedItem)
+        for (const [sectionId, subitems] of groupedBySection.entries()) {
+            if (item.href === sectionId) {
+                // Parent already covers this section, keep subitems flat
+                newSubitems.push(...subitems)
+                continue
             }
+            if (subitems.length === 1) {
+                // Single item, keep as-is
+                newSubitems.push(subitems[0])
+            } else {
+                const { parent, fragments } = separateParentAndFragments(sectionId, subitems)
+                if (parent) {
+                    // Natural parent exists, group fragment items under it
+                    parent.subitems = fragments.length > 0 ? fragments : parent.subitems
+                    newSubitems.push(parent)
+                } else {
+                    // No natural parent among subitems, keep them flat
+                    newSubitems.push(...subitems)
+                }
+            }
+        }
 
             item.subitems = newSubitems
         }


### PR DESCRIPTION
Following up on #6, this fixes a remaining grouping issue.

The previous fix addressed the case where a parent chapter and its subchapters share the same file (e.g. `chapter.htm` as parent, `chapter.htm#part_01` & `chapter.htm#part_02` as children).
This PR addresses a related case: when a parent chapter links to one file (e.g. `chapter.htm`) and its subchapters all link to a different file with fragment anchors (e.g. `story.htm#part_01`, `story.htm#part_02`), an unintended wrapper entry for `story.htm` would be injected between the parent and its subchapters, with the subchapters incorrectly nested under it.

This fix checks whether a natural parent exists among the grouped subitems before creating a wrapper. If none exists, the subitems are kept flat, matching the original `nav.xhtml` structure.

I'm attaching a test ebook (here: [Another_test_epub.zip](https://github.com/user-attachments/files/25615813/Another_test_epub.zip)) to reproduce the issue and verify the fix, since I can't share the original ebook where this issue occurs due to copyright.

### The problem & the fix at a glance

<img width="579" height="896" alt="delete_before" src="https://github.com/user-attachments/assets/c7700901-c73f-475b-b9c4-9bf38f6bb2d6" />