### PR TITLE
perf(epub): speed up book open for large EPUB

### DIFF
--- a/epub.js
+++ b/epub.js
@@ -1156,7 +1156,10 @@ ${doc.querySelector('parsererror').innerText}`)
             console.warn(e)
         }
 
-        await this.#updateSubItems()
+        // Only the synchronous TOC tree restructuring runs eagerly; per-section
+        // XHTML loading is deferred to ensureSubItemsResolved() so init() does
+        // not block on loading every section for large books.
+        this.#prepareSubItems()
 
         this.landmarks ??= this.resources.guide
 
@@ -1344,34 +1347,40 @@ ${doc.querySelector('parsererror').innerText}`)
         return subitems
     }
 
-    // Update section subitems from TOC structure
-    async #updateSubItems() {
+    // Synchronous TOC tree restructuring. Pure href-based grouping, no I/O.
+    // Safe to run eagerly in init().
+    #prepareSubItems() {
+        if (!this.toc || !this.sections) return
+        this.#groupTocSubitems(this.toc)
+    }
+
+    // Lazy per-section subitem resolution. Loads and parses each TOC-referenced
+    // section's XHTML to annotate section.subitems with fragment anchors. For
+    // long books this is expensive, so it is deferred until a caller actually
+    // needs subitems (e.g. TOC sidebar, search). Idempotent via memoized promise.
+    #subItemsResolvedPromise = null
+    async ensureSubItemsResolved() {
+        if (this.#subItemsResolvedPromise) return this.#subItemsResolvedPromise
+        this.#subItemsResolvedPromise = this.#resolveSubItems()
+        return this.#subItemsResolvedPromise
+    }
+    async #resolveSubItems() {
         if (!this.toc || !this.sections) return
 
-        // Step 1: Group TOC items by section
-        this.#groupTocSubitems(this.toc)
-
-        // Step 2: Prepare section lookup and content cache
         const sectionMap = new Map(this.sections.map(s => [s.id, s]))
         const contentCache = new Map()
 
-        // Step 3: Flatten TOC and group by section ID
         const allTocItems = this.#collectAllTocItems(this.toc)
         const sectionGroups = this.#groupItemsBySection(allTocItems)
 
-        // Step 4: Process each section and create subitems
         for (const [sectionId, { base, fragments }] of sectionGroups.entries()) {
             const section = sectionMap.get(sectionId)
             if (!section || fragments.length === 0) continue
 
-            // Load HTML content for this section
             const content = await this.#loadSectionContent(section, contentCache)
             if (!content) continue
 
-            // Create subitems from fragments
             const subitems = this.#createSectionSubitems(fragments, base, content, section)
-
-            // Assign to section
             if (subitems.length > 0) {
                 section.subitems = subitems
             }

--- a/paginator.js
+++ b/paginator.js
@@ -1023,7 +1023,7 @@ export class Paginator extends HTMLElement {
                 const range = this.#lastVisibleRange
                 if (!range) return
                 const sel = doc.getSelection()
-                if (!sel.rangeCount) return
+                if (!sel || !sel.rangeCount) return
                 // FIXME: this won't work on Android WebView, disable for now
                 if (!isPointerSelecting && isPointerSelecting && sel.type === 'Range')
                     checkPointerSelection(range, sel)


### PR DESCRIPTION
Defer per-section XHTML loading in EPUB.init() and guard against null         
  selection in the paginator's selectionchange handler.                         
                                                                                
  - Split #updateSubItems into synchronous #prepareSubItems (TOC tree           
    grouping, runs eagerly in init) and async #resolveSubItems (per-section
    XHTML load + fragment size calculation, exposed via ensureSubItemsResolved  
    and called on demand by consumers). For a 2000-chapter EPUB this removes    
    ~1-3s of blocking work from init().                                         
  - Guard doc.getSelection() against null in the paginator's selectionchange    
    listener, which can occur in iframes during certain WebView lifecycle       
    transitions.