### PR TITLE
fix(opds): resolve build syntax and unsafe isNaN lint errors

### DIFF
--- a/opds.js
+++ b/opds.js
@@ -122,7 +122,7 @@ const getPrice = link => {
     if (!prices.length) return
     const parsed = prices.reduce((acc, price) => {
         const value = parseFloat(price.textContent)
-        if (!isNaN(value)) {
+        if (!Number.isNaN(value)) {
             acc.push({
                 currency: price.getAttribute('currencycode') ?? undefined,
                 value,
@@ -178,7 +178,7 @@ const getLink = link => {
         type: link.getAttribute('type') ?? undefined,
         title: link.getAttribute('title') ?? undefined,
         // --- Facet Grouping ---
-        [FACET_GROUP]: link.getAttributeNS(NS.OPDS, 'facetGroup') || link.getAttribute('opds:facetGroup') ?? undefined,
+        [FACET_GROUP]: (link.getAttributeNS(NS.OPDS, 'facetGroup') || link.getAttribute('opds:facetGroup')) ?? undefined,
         properties: {
             price: (isAcquisition || isStream) ? getPrice(link) : undefined,
             indirectAcquisition: (isAcquisition || isStream) ? getIndirectAcquisition(link) : undefined,


### PR DESCRIPTION
This is a quick follow-up to PR #14 to address a couple of minor build and linting issues encountered while compiling and rebasing `readest` with the latest parser update.

### What's changed
* **Build Fix (Syntax Error):** Added missing parentheses around the `||` logical expression when mixed with the `??` nullish coalescing operator in `getLink`. Modern parsers require explicit grouping to prevent ambiguity.
* **Lint Fix (`noGlobalIsNan`):** Replaced the global `isNaN()` check with `Number.isNaN()` inside the `getPrice` reducer. This resolves a Biome linter warning regarding unsafe type coercion, making the number validation stricter.