### PR TITLE
fix(opds): support mixed feed items parsing

### DIFF
--- a/opds.js
+++ b/opds.js
@@ -266,13 +266,33 @@ export const getFeed = doc => {
                     children.find(filter('content'))) ?? undefined,
             })
 
+        // Flag the item with its resolved OPDS 2.0 type
+        item.__type = isPub ? 'publication' : 'navigation'
+
         const arr = groupedItems.get(groupLink?.href)
         if (arr) arr.push(item)
         else groupedItems.set(groupLink.href, [item])
     }
-    const [items, ...groups] = Array.from(groupedItems, ([key, items]) => {
-        const itemsKey = items[0]?.metadata ? 'publications' : 'navigation'
-        if (key === undefined) return { [itemsKey]: items }
+
+    const [items, ...groups] = Array.from(groupedItems, ([key, groupItems]) => {
+        // Separate publications and navigation items within the group
+        const publications = []
+        const navigation = []
+        for (const item of groupItems) {
+            if (item.__type === 'publication') {
+                delete item.__type
+                publications.push(item)
+            } else {
+                delete item.__type
+                navigation.push(item)
+            }
+        }
+
+        const groupContent = {}
+        if (publications.length) groupContent.publications = publications
+        if (navigation.length) groupContent.navigation = navigation
+
+        if (key === undefined) return groupContent
         const link = groupLinkMap.get(key)
         return {
             metadata: {
@@ -280,7 +300,7 @@ export const getFeed = doc => {
                 numberOfItems: link?.properties?.numberOfItems,
             },
             links: [{ rel: 'self', href: link?.href, type: link?.type }],
-            [itemsKey]: items,
+            ...groupContent,
         }
     })
 
@@ -308,7 +328,7 @@ export const getFeed = doc => {
         links,
         isComplete: !!children.find(filterFH('complete')) || undefined,
         isArchive: !!children.find(filterFH('archive')) || undefined,
-        ...items,
+        ...items, // contains top-level 'publications' and/or 'navigation' arrays
         groups: groups.length ? groups : undefined,
         facets: Array.from(
             groupByArray(linksByRel.get(REL.FACET) ?? [], link => link[FACET_GROUP]),


### PR DESCRIPTION
This is a follow-up to PR #14 to refine the handling of mixed OPDS feeds.

### What's changed
* **Robust Feed Separation:** Even though the OPDS 1.2 spec implicitly states that a feed should be strictly either *Acquisition* or *Navigation*, some servers (like Copyparty) send mixed feeds containing both books and folders in the same response. I've modified the `getFeed` parsing logic to intelligently segregate `publications` and `navigation` arrays on a per-item basis instead of relying entirely on the very first entry. This restores support for such non-standard yet practical implementations found in the wild.