### PR TITLE
feat: expose standalone OPF + MOBI metadata extractors

### DIFF
--- a/epub.js
+++ b/epub.js
@@ -1228,3 +1228,24 @@ ${doc.querySelector('parsererror').innerText}`)
         this.#loader?.destroy()
     }
 }
+
+// Standalone OPF metadata extractor.
+//
+// Exposed so callers that already have the OPF bytes in hand (e.g. a
+// platform-native pre-parser that read the zip on a faster runtime)
+// can derive `Book.metadata` without driving the full `EPUB.init()` —
+// which would force `@zip.js/zip.js` to scan the central directory
+// and inflate nav.xhtml/ncx the importer never reads. The output
+// shape is identical to what `EPUB.init()` would produce, so the
+// import-path BookDoc and the reader-path BookDoc remain byte-stable
+// across `Book.metadata.identifier`, title, contributors, refines
+// chains, ONIX5, and `belongs-to-collection`.
+//
+// Two entry points to fit different callers:
+//   - `getEpubMetadata(opfDoc)`        — already-parsed OPF Document
+//   - `parseEpubMetadataFromXML(xml)`  — raw OPF XML string
+export const getEpubMetadata = opf => getMetadata(opf)
+export const parseEpubMetadataFromXML = xml => {
+    const opf = new DOMParser().parseFromString(xml, 'application/xml')
+    return getMetadata(opf)
+}

--- a/mobi.js
+++ b/mobi.js
@@ -519,7 +519,7 @@ export class MOBI extends PDB {
         super()
         this.unzlib = unzlib
     }
-    async open(file) {
+    async open(file, { metadataOnly = false } = {}) {
         await super.open(file)
         // TODO: if (this.pdb.type === 'TEXt')
         this.headers = this.#getHeaders(await super.loadRecord(0))
@@ -538,6 +538,13 @@ export class MOBI extends PDB {
             }
         }
         await this.#setup()
+        // Metadata-only short-circuit. Skips the (expensive) MOBI6 /
+        // KF8 init(), which walks every text record and parses
+        // fdst/skel/frag indices the importer never reads.
+        // `this.headers` and `this.decode()` are already populated by
+        // #setup, so `this.getMetadata()` and `this.getCover()` are
+        // the only surfaces the caller is allowed to use here.
+        if (metadataOnly) return this
         return isKF8 ? new KF8(this).init() : new MOBI6(this).init()
     }
     #getHeaders(buf) {
@@ -1238,5 +1245,35 @@ class KF8 {
     }
     destroy() {
         for (const url of this.#cache.values()) URL.revokeObjectURL(url)
+    }
+}
+
+// Standalone MOBI metadata + cover extractor.
+//
+// Drives just enough of `MOBI.open()` to populate `this.headers` and
+// `this.decode()` — the PalmDB header, the record offsets table,
+// record 0 (PalmDoc header + MobiHeader + EXTH), and the decoder /
+// decompressor hookup. Crucially it does **not** drive
+// `new MOBI6(this).init()` / `new KF8(this).init()`: those walk every
+// text record in the book (decompressing and parsing fdst/skel/frag
+// indices), which is the expensive part of opening a MOBI and the
+// importer never reads any of their outputs.
+//
+// The result is byte-stable against `MOBI.open()`'s metadata path —
+// `identifier` is `mobi.uid.toString()` (PalmDB UID, foliate's
+// canonical MOBI identifier), title/author/etc. go through the same
+// `unescapeHTML` paths in `getMetadata()` — so callers (e.g. a
+// platform-native pre-parser) can build a `Book.metadata` that
+// matches what the reader path produces, without paying for the
+// `init()` work the importer doesn't consume.
+//
+// Returns `{ metadata, getCover }` where `getCover` is a thunk that
+// loads the cover record on demand (the importer typically prefers
+// a pre-resized cover from the native side and ignores this).
+export const readMobiMetadata = async (file, { unzlib } = {}) => {
+    const m = await new MOBI({ unzlib }).open(file, { metadataOnly: true })
+    return {
+        metadata: m.getMetadata(),
+        getCover: m.getCover.bind(m),
     }
 }


### PR DESCRIPTION
Add two narrowly-scoped entry points so callers that already hold the
underlying bytes (for example a platform-native pre-parser that read
the file on a faster runtime) can derive a `Book.metadata` that
matches what the full reader path produces, without paying for the
expensive parts of `EPUB.init()` / `MOBI.open()`.

## `epub.js`

- `export const getEpubMetadata(opfDoc)` — wraps the existing
  module-internal `getMetadata()` so callers with an already-parsed
  OPF `Document` can use it directly.
- `export const parseEpubMetadataFromXML(xmlString)` — convenience
  that `DOMParser`s the raw OPF first.

Output is identical to what `EPUB.init()` would produce, so refines
chains, ONIX5 codelists, language maps, `belongs-to-collection`,
identifier resolution via `<package unique-identifier>` all behave
the same. Useful for an importer that has the OPF bytes in hand and
wants to skip `@zip.js/zip.js`'s central-directory scan plus the
`nav.xhtml` / `toc.ncx` inflate that `EPUB.init()` drives but the
importer never reads.

## `mobi.js`

- `MOBI.open(file, { metadataOnly = false })` — new `metadataOnly`
  short-circuit that returns `this` after `#setup()`, so callers can
  use `this.headers` / `this.decode()` / `this.getMetadata()` /
  `this.getCover()` without paying for the `MOBI6` / `KF8` `init()`
  that walks every text record and builds fdst/skel/frag indices.
- `export const readMobiMetadata(file, { unzlib })` — convenience
  wrapper around the metadata-only path that returns
  `{ metadata, getCover }`. `metadata.identifier` stays
  `mobi.uid.toString()` (PalmDB UID), matching the existing reader
  path.

## Compatibility

No behavioural changes to existing class APIs:

- `EPUB.init()` is unchanged.
- `MOBI.open(file)` (no second arg) is unchanged — the new
  `metadataOnly` option defaults to `false`.

Existing call sites in this repo and in downstream consumers
(readest-app's `DocumentLoader`, `comic-book.js`, etc.) keep working
with no change.

## Why

The Tauri build of [readest](https://github.com/readest/readest) has
a Rust-side EPUB / MOBI pre-parser that handles the mechanical zip /
PalmDB work (partialMD5, cover decode + downscale, OPF byte read).
Currently the JS side either:

1. duplicates foliate-js's metadata extractor in Rust (drift risk
   on refines / ONIX5 / `mobi.uid`-vs-ISBN / etc.), or
2. routes the importer through `DocumentLoader.open()` to reuse
   foliate-js — which then forces zip.js to scan the entire EPUB
   central directory and `MOBI.open()` to walk every text record,
   regressing import time by 5-10x on mid-tier mobile.

These two exports give option 3: keep foliate-js as the single
source of truth for OPF / EXTH semantics, but only run the parts of
it the importer actually consumes. See
[readest/readest#perf-rust-epub](https://github.com/readest/readest)
for the consumer side.
