### PR TITLE
fix(paginator): correct RTL rect mapper for multi-view layouts

### DIFF
--- a/paginator.js
+++ b/paginator.js
@@ -1820,10 +1820,24 @@ export class Paginator extends HTMLElement {
                     ({ left: size - right - marginTop, right: size - left - marginBottom })
                 : ({ top, bottom }) => ({ left: top - marginTop, right: bottom - marginBottom })
         }
-        const pxSize = this.#renderedPages * this.size
+        // For RTL the mapper mirrors a rect within the iframe-local
+        // coordinate space of the *target view* (each view is a separate
+        // document with its own column layout), not across the whole
+        // container. Using `#renderedPages * size` (= total width of all
+        // loaded views) was correct only when a single view was loaded;
+        // once #fillVisibleArea pre-loads adjacent sections the total
+        // width grows but the per-view rect coordinates do not change,
+        // so the mapper would scroll the same anchor to a different
+        // (further-right) container offset on every re-anchor — driving
+        // the page off the user's saved position. Use the supplied
+        // view's width when available, falling back to the primary view.
+        const targetView = view ?? this.#primaryView
+        const viewSize = targetView
+            ? targetView.element.getBoundingClientRect()[this.sideProp]
+            : this.#renderedViewSize
         return this.#rtl
             ? ({ left, right }) =>
-                ({ left: pxSize - right, right: pxSize - left })
+                ({ left: viewSize - right, right: viewSize - left })
             : this.#vertical
                 ? ({ top, bottom }) => ({ left: top, right: bottom })
                 : f => f


### PR DESCRIPTION
## Problem
If you read an Arabic book by Readest, the  reading progress is not correctly saved and opened. 

In RTL paginated flow, the rect mapper mirrors iframe-local coordinates so the rest of the engine can reason about pages as if they were LTR. The mirror reference width was computed as `#renderedPages * this.size`, which equals the total width across **all** loaded views, not just the view the rect belongs to.

That happened to be correct when only the primary view was loaded, so the bug stayed hidden. As soon as `#fillVisibleArea` started pre-loading adjacent sections, the total width grew while per-view rect coordinates stayed the same. Every re-anchor then mapped the same anchor rect to a progressively further-right container offset, scrolling the user away from their saved position and emitting `relocate` events for the wrong page — which the host app's auto-save then persisted as the new reading progress.

End-user symptom (reproduced with an Arabic EPUB): close a book at e.g. chapter 2 page 14 and re-open it; the reader briefly lands near the saved position, then jumps several chapters forward as adjacent sections finish loading, and that wrong location overwrites the saved progress.
<img width="398" height="922" alt="image" src="https://github.com/user-attachments/assets/09efb691-17e5-4759-9221-24132d295a73" />


## Fix

Mirror within the iframe-local coordinate space of the rect's **own** view, falling back to the primary view when the caller doesn't pass one. LTR, scrolled, and vertical-writing paths are untouched.

## Scope

Only RTL paginated flow with multiple loaded views (i.e. anything triggering `#fillVisibleArea`). Single-view RTL behaviour is unchanged because `viewSize === renderedPages * size` in that case.