### PR TITLE
fix(paginator): guard scrollBy/snap against uninitialized scrollBounds

### DIFF
--- a/paginator.js
+++ b/paginator.js
@@ -1687,6 +1687,13 @@ export class Paginator extends HTMLElement {
     }
 
     scrollBy(dx, dy) {
+        // #scrollBounds is populated by #scrollToPage and stays unset until
+        // the first page settles. A swipe that lands before that happens
+        // (for example a fast swipe right after the reader mounts, or
+        // before a section has finished loading) would otherwise blow up
+        // on the destructuring below — bail out and let the next settled
+        // scroll re-enable swipe-driven motion.
+        if (!this.#scrollBounds) return
         const delta = this.#vertical ? dy : dx
         const [offset, a, b] = this.#scrollBounds
         const rtl = this.#rtl
@@ -1700,6 +1707,11 @@ export class Paginator extends HTMLElement {
     // dx, dy: total distance swiped
     // dt: total time of the swipe (ms)
     snap(vx, vy, dx, dy, dt) {
+        // Same guard as scrollBy: an early swipe whose touchend fires
+        // before the first #scrollToPage seeds #scrollBounds would crash
+        // on the destructuring. Skip the snap; the next settled scroll
+        // populates the bounds and subsequent swipes work normally.
+        if (!this.#scrollBounds) return
         const velocity = this.#vertical ? vy : vx
         const avgVelocity = this.#vertical ? dy / dt : dx / dt
         const horizontal = Math.abs(vx) * 2 > Math.abs(vy)


### PR DESCRIPTION
#scrollBounds is only populated as a side effect of #scrollToPage, so it stays unset until the first page settles. Touch-driven entry points (scrollBy / snap, both on the swipe path) destructure it without checking for that, which crashes with

  TypeError: undefined is not iterable (cannot read property
  Symbol(Symbol.iterator)) at Paginator.snap

whenever a user swipes before the first scroll lands — most easily reproduced by a fast swipe right after the reader mounts or while a section is still loading.

Bail out of both methods when #scrollBounds is null so the swipe is ignored rather than fatal; the next settled scroll seeds the bounds and subsequent swipes work normally.