### PR TITLE
fix(paginator): keep scrolled-mode scrollbar from vanishing after open

### DIFF
--- a/paginator.js
+++ b/paginator.js
@@ -1048,6 +1048,14 @@ export class Paginator extends HTMLElement {
             overflow: auto;
             overflow-anchor: auto;
             flex-direction: column;
+            /* Composite the scroll container so its scrollbar repaints on the
+               compositor thread; the main-thread scrollbar fails to
+               re-invalidate after content-size changes (adjacent-section
+               preloading right after open), so on Windows' always-on
+               scrollbars it vanishes shortly after the book opens
+               (readest#4470). Scoped to scrolled mode to leave the paginated
+               page-turn path un-composited. */
+            transform: translateZ(0);
         }
         :host([flow="scrolled"]) #container.vertical {
             flex-direction: row;


### PR DESCRIPTION
## Problem

In **scrolled mode** the scrollbar appears when a book opens and then disappears a moment later. Reported downstream as readest/readest#4470 (Windows, where scrollbars are always-on classic scrollbars; macOS overlay scrollbars auto-hide so it went unnoticed).

## Root cause

The scrolled-mode scrollbar lives on `#container` (`overflow: auto`). That container used to carry a `transform: translateZ(0)` compositing hint, which makes Chromium paint a **composited** scrollbar that repaints on the compositor thread. The hint was stripped from both `#container` and `#container > *` in `c1c7315` ("perf: fallback to raf animate scroll for large sections"). The perf win there was removing the **oversized child-view** layers (`#container > *`); the container's own hint was collateral.

Without it the scroller falls back to a main-thread scrollbar that fails to re-invalidate after the container's content size changes — which happens right after open, when adjacent sections are preloaded and `scrollHeight` jumps. So the scrollbar is drawn on first paint, then vanishes on the first content mutation.

## Fix

Restore `transform: translateZ(0)` on the scroll container, **scoped to scrolled mode** (`:host([flow="scrolled"]) #container`). The paginated page-turn path your perf commit targeted stays un-composited (the `#container > *` children remain un-hinted), and in scrolled mode a composited scroller is the desired GPU-accelerated path anyway.

## Verification

⚠️ Diagnosed by code inspection of the regression window. The symptom is Windows-specific (always-on scrollbars) and can't be faithfully reproduced on macOS — overlay scrollbars auto-hide regardless, and forcing classic scrollbars via CSS changes the paint path and would mask the compositor behavior. Needs a Windows check to confirm the scrollbar stays after opening a book in scrolled mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)