### PR TITLE
fix(overlayer): split highlight ranges by text nodes so all block types get rects

### DIFF
--- a/overlayer.js
+++ b/overlayer.js
@@ -74,42 +74,61 @@ export class Overlayer {
         }
         return 1.0
     }
-    #splitRangeByParagraph(range) {
+    // Split a range into per-text-node sub-ranges (plus replaced elements
+    // like images), so `getClientRects()` only ever returns line-level boxes.
+    // Collecting rects on the whole range would also include the border boxes
+    // of fully contained block elements, over-highlighting blank space.
+    #splitRange(range) {
         const ancestor = range.commonAncestorContainer
-        const paragraphs = Array.from(ancestor.querySelectorAll?.('p, h1, h2, h3, h4') || [])
-
+        if (ancestor.nodeType !== Node.ELEMENT_NODE
+            && ancestor.nodeType !== Node.DOCUMENT_NODE) return [range]
+        const doc = ancestor.ownerDocument ?? ancestor
+        const walker = doc.createTreeWalker(ancestor,
+            NodeFilter.SHOW_TEXT | NodeFilter.SHOW_ELEMENT, {
+                acceptNode: node => {
+                    if (!range.intersectsNode(node)) return NodeFilter.FILTER_REJECT
+                    if (node.nodeType === Node.TEXT_NODE) return NodeFilter.FILTER_ACCEPT
+                    return node.matches?.('img, svg')
+                        ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_SKIP
+                },
+            })
         const splitRanges = []
-        paragraphs.forEach((p) => {
-            const pRange = document.createRange()
-            if (range.intersectsNode(p)) {
-                pRange.selectNodeContents(p)
-                if (pRange.compareBoundaryPoints(Range.START_TO_START, range) < 0) {
-                    pRange.setStart(range.startContainer, range.startOffset)
+        for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+            const subRange = doc.createRange()
+            if (node.nodeType === Node.TEXT_NODE) {
+                subRange.selectNodeContents(node)
+                if (subRange.compareBoundaryPoints(Range.START_TO_START, range) < 0) {
+                    subRange.setStart(range.startContainer, range.startOffset)
                 }
-                if (pRange.compareBoundaryPoints(Range.END_TO_END, range) > 0) {
-                    pRange.setEnd(range.endContainer, range.endOffset)
+                if (subRange.compareBoundaryPoints(Range.END_TO_END, range) > 0) {
+                    subRange.setEnd(range.endContainer, range.endOffset)
                 }
-                splitRanges.push(pRange)
-            }
-        })
+            } else subRange.selectNode(node)
+            splitRanges.push(subRange)
+        }
         return splitRanges.length === 0 ? [range] : splitRanges
+    }
+    #getRects(range) {
+        const zoom = this.#zoom
+        const rects = []
+        for (const subRange of this.#splitRange(range)) {
+            for (const rect of subRange.getClientRects()) {
+                rects.push({
+                    left: rect.left * zoom,
+                    top: rect.top * zoom,
+                    right: rect.right * zoom,
+                    bottom: rect.bottom * zoom,
+                    width: rect.width * zoom,
+                    height: rect.height * zoom,
+                })
+            }
+        }
+        return rects
     }
     add(key, range, draw, options) {
         if (this.#map.has(key)) this.remove(key)
         if (typeof range === 'function') range = range(this.#svg.getRootNode())
-        const zoom = this.#zoom
-        let rects = []
-        this.#splitRangeByParagraph(range).forEach((pRange) => {
-            const pRects = Array.from(pRange.getClientRects()).map(rect => ({
-                left: rect.left * zoom,
-                top: rect.top * zoom,
-                right: rect.right * zoom,
-                bottom: rect.bottom * zoom,
-                width: rect.width * zoom,
-                height: rect.height * zoom,
-            }))
-            rects = rects.concat(pRects)
-        })
+        const rects = this.#getRects(range)
         const element = draw(rects, options)
         this.#svg.append(element)
         this.#map.set(key, { range, draw, options, element, rects })
@@ -123,19 +142,7 @@ export class Overlayer {
         for (const obj of this.#map.values()) {
             const { range, draw, options, element } = obj
             this.#svg.removeChild(element)
-            const zoom = this.#zoom
-            let rects = []
-            this.#splitRangeByParagraph(range).forEach((pRange) => {
-                const pRects = Array.from(pRange.getClientRects()).map(rect => ({
-                    left: rect.left * zoom,
-                    top: rect.top * zoom,
-                    right: rect.right * zoom,
-                    bottom: rect.bottom * zoom,
-                    width: rect.width * zoom,
-                    height: rect.height * zoom,
-                }))
-                rects = rects.concat(pRects)
-            })
+            const rects = this.#getRects(range)
             const el = draw(rects, options)
             this.#svg.append(el)
             obj.element = el


### PR DESCRIPTION
## Problem

A highlight spanning paragraphs **and** a bullet list paints the paragraphs but not the list items (readest reader, web + native):

The overlayer splits a range into sub-ranges before collecting client rects so that fully-contained block elements don't contribute their border boxes (which over-highlight blank space between lines/paragraphs). The split was keyed on a hard-coded selector `'p, h1, h2, h3, h4'`, so text in any other block container — `li`, `blockquote`, `dd`, `td`, … — fell into no sub-range and was silently dropped from the drawn SVG whenever the range also touched a matching paragraph/heading. (A highlight entirely inside a list worked only via the empty-split `[range]` fallback.) Headings were already retrofitted into the selector once (`920676b`); `li` is the same hole again.

## Fix

Split by **text nodes** instead (TreeWalker with subtree pruning, plus replaced elements `img, svg`), clipping the first/last text node to the range boundaries:

- text-node rects are always line-level boxes → still never any block border boxes (the reason the split exists),
- covers every block type with no tag whack-a-mole,
- can't double-paint nested blocks like `li > p` (text nodes don't nest).

The rect collection shared by `add()` and `redraw()` is factored into `#getRects`.

## Verification

- Unit tests live in the app repo (`readest`): `src/__tests__/document/overlayer-highlight-blocks.test.ts` — li/blockquote coverage, `li > p` no-double-draw, boundary clipping, img rects (3 of 5 failed before this fix).
- Verified live in the web reader: a saved highlight spanning two paragraphs and a 4-item `<ul>` now draws one line-level rect per wrapped list line, geometry matching the `li` line boxes exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)