### PR TITLE
fix(opds): treat metadata-only entries without acquisition links as publications

### DIFF
--- a/opds.js
+++ b/opds.js
@@ -252,8 +252,18 @@ export const getFeed = doc => {
         const children = Array.from(entry.children)
         const links = children.filter(filter('link')).map(getLink)
         const linksByRel = groupByArray(links, link => link.rel)
-        const isPub = Array.from(linksByRel.keys())
+        const hasAcquisition = Array.from(linksByRel.keys())
             .some(rel => rel?.startsWith(REL.ACQ) || rel === 'preview' || rel === REL.STREAM)
+        // An entry with neither an acquisition link nor a link to a sub-catalog,
+        // but which carries a cover/thumbnail image, is a publication that simply
+        // has no downloadable format (e.g. a Calibre book whose file was removed
+        // but whose metadata is kept). Treat it as a publication so its metadata
+        // is shown; otherwise it falls through to the navigation branch with the
+        // cover image as its href, and tapping it tries to parse the image as a
+        // feed (readest issue #4599).
+        const hasNavLink = links.some(link => isOPDSCatalog(link.type))
+        const hasImage = REL.COVER.concat(REL.THUMBNAIL).some(rel => linksByRel.has(rel))
+        const isPub = hasAcquisition || (!hasNavLink && hasImage)
 
         const groupLinks = linksByRel.get(REL.GROUP) ?? linksByRel.get('collection')
         const groupLink = groupLinks?.length


### PR DESCRIPTION
## Problem

An OPDS entry with full metadata and a cover image but **no acquisition link** is misclassified as a navigation item.

In `getFeed`, an entry is treated as a publication only if it has an `acquisition`/`preview`/`stream` rel. Otherwise it falls into the navigation branch, whose href is `links.find(isOPDSCatalog) ?? links[0]`. When the entry has no sub-catalog link, that falls back to `links[0]` — which for such an entry is the **cover image** link.

A client then renders it as a navigation entry; tapping it loads the cover image URL and tries to parse the image bytes as a feed, crashing with a JSON parse error.

This happens in practice with Calibre-server: a book whose file was removed (e.g. a borrowed/loaned title kept only for metadata tracking) still emits a full entry with cover/thumbnail links but no acquisition link.

## Fix

Classify an entry as a publication when it has an acquisition link **or** it has no link to a sub-catalog but carries a cover/thumbnail image:

```js
const isPub = hasAcquisition || (!hasNavLink && hasImage)
```

- `hasNavLink = links.some(link => isOPDSCatalog(link.type))`
- `hasImage` = any `REL.COVER` / `REL.THUMBNAIL` rel present

Such metadata-only entries are now shown as publications (their metadata is displayed, with no downloadable format) instead of being navigable to a non-feed resource. True navigation entries (a sub-catalog link, no image) are unchanged.

## Notes

Downstream issue: readest/readest#4599

Verified in readest via `src/__tests__/utils/opds-feed.test.ts` (new cases for the Calibre no-format entry and a regression guard that a real navigation entry still classifies as navigation).