### PR TITLE
fix(search): show excerpt context for matches inside styled text nodes

### DIFF
--- a/search.js
+++ b/search.js
@@ -3,16 +3,33 @@ const CONTEXT_LENGTH = 50
 
 const normalizeWhitespace = str => str.replace(/\s+/g, ' ')
 
+// Gather context preceding the match by walking back across text nodes until we
+// have enough for the excerpt. A match can sit in its own text node (e.g. a word
+// wrapped in <i>/<em>/<b>), leaving no context within the start node itself.
+const collectBefore = (strs, index, offset) => {
+    let str = strs[index].slice(0, offset)
+    for (let i = index - 1; i >= 0 && normalizeWhitespace(str).trim().length < CONTEXT_LENGTH; i--)
+        str = strs[i] + str
+    return str
+}
+
+const collectAfter = (strs, index, offset) => {
+    let str = strs[index].slice(offset)
+    for (let i = index + 1; i < strs.length && normalizeWhitespace(str).trim().length < CONTEXT_LENGTH; i++)
+        str += strs[i]
+    return str
+}
+
 const makeExcerpt = (strs, { startIndex, startOffset, endIndex, endOffset }) => {
     const start = strs[startIndex]
     const end = strs[endIndex]
-    const match = start === end
+    const match = startIndex === endIndex
         ? start.slice(startOffset, endOffset)
         : start.slice(startOffset)
-            + strs.slice(start + 1, end).join('')
+            + strs.slice(startIndex + 1, endIndex).join('')
             + end.slice(0, endOffset)
-    const trimmedStart = normalizeWhitespace(start.slice(0, startOffset)).trimStart()
-    const trimmedEnd = normalizeWhitespace(end.slice(endOffset)).trimEnd()
+    const trimmedStart = normalizeWhitespace(collectBefore(strs, startIndex, startOffset)).trimStart()
+    const trimmedEnd = normalizeWhitespace(collectAfter(strs, endIndex, endOffset)).trimEnd()
     const ellipsisPre = trimmedStart.length < CONTEXT_LENGTH ? '' : '…'
     const ellipsisPost = trimmedEnd.length < CONTEXT_LENGTH ? '' : '…'
     const pre = `${ellipsisPre}${trimmedStart.slice(-CONTEXT_LENGTH)}`


### PR DESCRIPTION
## Problem

In fulltext search, a match that falls inside inline-styled text (e.g. a word wrapped in `<i>`/`<em>`/`<b>`) lands in its **own** text node, because `textWalker` maps each DOM text node to one entry of the `strs[]` array.

`makeExcerpt` built the surrounding `pre`/`post` context only from *within* the start/end node:

```js
const trimmedStart = normalizeWhitespace(start.slice(0, startOffset)).trimStart()
const trimmedEnd   = normalizeWhitespace(end.slice(endOffset)).trimEnd()
```

For a standalone styled word that text is empty, so the excerpt showed only the matched word with no context. Plain words sit in a node alongside their neighbours, so they were unaffected.

Reported in readest/readest#4594 (italicized word → no context).

## Fix

- Gather context across neighbouring `strs[]` entries with `collectBefore`/`collectAfter`, bounded to `CONTEXT_LENGTH` so it never joins the whole section per match.
- Fix two latent multi-node bugs in the `match` branch that bite phrases spanning a styling boundary:
  - `start === end` → `startIndex === endIndex` (compare indices, not string values).
  - `strs.slice(start + 1, end)` → `strs.slice(startIndex + 1, endIndex)` — the string values coerced to `NaN` → `0`, silently dropping the middle text nodes.

## Verification

Regression test added on the readest side (covers both `simpleSearch` and `segmenterSearch` paths). Verified live against a real EPUB: the italic occurrence of a word now renders full context, identical to its plain occurrences; before the fix `pre`/`post` were empty.
