### PR TITLE
fix(epub): escape stray ampersands so malformed OPF/XML parses

### DIFF
--- a/epub.js
+++ b/epub.js
@@ -1038,6 +1038,24 @@ const getDisplayOptions = doc => {
     }
 }
 
+// Some EPUBs ship an OPF/NCX/nav doc that isn't well-formed XML: either named
+// HTML entities that XML doesn't predefine (`&nbsp;` …), or — worse — a bare
+// `&` that was never escaped (e.g. a hand-built manifest id like
+// `id="Search_&_Rescue"`). A strict XML parser rejects both, failing the whole
+// import. Map the known named entities to numeric refs, then escape any
+// remaining `&` that doesn't begin a valid character/entity reference so the
+// document parses instead.
+const xmlNamedEntities = {
+    nbsp: '&#160;', mdash: '&#8212;', ndash: '&#8211;',
+    ldquo: '&#8220;', rdquo: '&#8221;', lsquo: '&#8216;', rsquo: '&#8217;',
+    hellip: '&#8230;', copy: '&#169;', reg: '&#174;', trade: '&#8482;',
+    bull: '&#8226;', middot: '&#183;',
+}
+const sanitizeXMLEntities = str => str
+    .replace(/&([a-z]+);/gi, (match, entity) =>
+        xmlNamedEntities[entity.toLowerCase()] ?? match)
+    .replace(/&(?!#\d+;|#x[0-9a-f]+;|[a-z][a-z0-9]*;)/gi, '&amp;')
+
 export class EPUB {
     parser = new DOMParser()
     #loader
@@ -1052,31 +1070,10 @@ export class EPUB {
         this.getSize = getSize
         this.#encryption = new Encryption(deobfuscators(sha1))
     }
-    #sanitizeXMLEntities(str) {
-        // Common HTML entities that aren't valid in XML
-        const entityMap = {
-            'nbsp': '&#160;',
-            'mdash': '&#8212;',
-            'ndash': '&#8211;',
-            'ldquo': '&#8220;',
-            'rdquo': '&#8221;',
-            'lsquo': '&#8216;',
-            'rsquo': '&#8217;',
-            'hellip': '&#8230;',
-            'copy': '&#169;',
-            'reg': '&#174;',
-            'trade': '&#8482;',
-            'bull': '&#8226;',
-            'middot': '&#183;',
-        }
-        return str.replace(/&([a-z]+);/gi, (match, entity) => {
-            return entityMap[entity.toLowerCase()] || match
-        })
-    }
     async #loadXML(uri) {
         const str = await this.loadText(uri)
         if (!str) return null
-        const sanitized = this.#sanitizeXMLEntities(str)
+        const sanitized = sanitizeXMLEntities(str)
         const doc = this.parser.parseFromString(sanitized, MIME.XML)
         if (doc.querySelector('parsererror'))
             throw new Error(`XML parsing error: ${uri}
@@ -1246,6 +1243,6 @@ ${doc.querySelector('parsererror').innerText}`)
 //   - `parseEpubMetadataFromXML(xml)`  — raw OPF XML string
 export const getEpubMetadata = opf => getMetadata(opf)
 export const parseEpubMetadataFromXML = xml => {
-    const opf = new DOMParser().parseFromString(xml, 'application/xml')
+    const opf = new DOMParser().parseFromString(sanitizeXMLEntities(xml), 'application/xml')
     return getMetadata(opf)
 }


### PR DESCRIPTION
## Problem

Some EPUBs ship an OPF that isn't well-formed XML: a bare, unescaped `&` — e.g. a hand-built manifest id like:

```xml
<item id="Chapter_1213_Search_&_Rescue_153" .../>
```

A strict XML parser reads `&`, then the name `_Rescue_153`, then hits `"` where it expected `;` and reports `EntityRef: expecting ';'`. The whole book then fails to open/import:

```
Failed to open the book file: XML parsing error: ...opf
... error on line 172 at column 43: EntityRef: expecting ';'
```

The existing sanitizer mapped named HTML entities (`&nbsp;` …) to numeric refs but never escaped a stray `&` that isn't part of any entity reference, so two parse sites still threw:

- `EPUB.init()` → `#loadXML` (web / desktop / Android reader-open)
- `parseEpubMetadataFromXML` (the readest native-bridge import path) — parsed **unsanitized**

## Fix

Extract a shared module-level `sanitizeXMLEntities()` and apply it at **both** entry points. In addition to the named-entity map, escape any `&` that doesn't begin a valid character/entity reference:

```
&(?!#\d+;|#x[0-9a-f]+;|[a-z][a-z0-9]*;)  ->  &amp;
```

Valid entities (`&amp;`, `&#160;`, `&nbsp;`→`&#160;`) are preserved — no double-escaping.

## Verification

- Verified end-to-end against the real "Shadow Slave - Vol. 6" EPUB: imports cleanly in the readest web app (Chrome) and on a physical Android device (native import path) where it previously failed.
- Covered by a unit test on the readest side (both `parseEpubMetadataFromXML` cases: raw `&` in a manifest id, raw `&` in text, and preservation of valid/numeric/named references).

🤖 Generated with [Claude Code](https://claude.com/claude-code)