### PR TITLE
fix(paginator): demote over-tall inline-block boxes so columns don't clip content

### DIFF
--- a/paginator.js
+++ b/paginator.js
@@ -603,7 +603,34 @@ class View {
             'position': 'static',
         })
         this.setImageSize(availableWidth, availableHeight)
+        this.#demoteUnfragmentableBoxes(availableHeight)
         this.expand()
+    }
+    // Atomic inline-level boxes (inline-block / inline-flex / inline-grid /
+    // inline-table) cannot be fragmented across columns. When an EPUB declares
+    // such a display on a tall block container, the box overflows the page and
+    // every column past the first is clipped, so whole sections silently vanish
+    // (e.g. a chapter that jumps straight to its references). Detect the
+    // vertical overflow this causes in paginated mode and demote the offending
+    // boxes to their fragmentable block-level equivalents so the content
+    // paginates normally. The querySelectorAll scan only runs when the document
+    // actually overflows its column, which is the (rare) bug case.
+    #demoteUnfragmentableBoxes(availableHeight) {
+        const doc = this.document
+        const root = doc?.documentElement
+        if (!root || root.scrollHeight <= root.clientHeight + 1) return
+        const view = doc.defaultView
+        const fragmentable = {
+            'inline-block': 'block',
+            'inline-flex': 'flex',
+            'inline-grid': 'grid',
+            'inline-table': 'table',
+        }
+        for (const el of doc.body.querySelectorAll('*')) {
+            const replacement = fragmentable[view.getComputedStyle(el).display]
+            if (replacement && el.getBoundingClientRect().height > availableHeight)
+                setStylesImportant(el, { display: replacement })
+        }
     }
     setImageSize(availableWidth, availableHeight) {
         const { width, height, marginTop, marginRight, marginBottom, marginLeft } = this.#layout


### PR DESCRIPTION
## Problem

Some EPUBs wrap a large chunk of chapter content in a `<div>` the stylesheet declares as `display: inline-block`. Atomic inline-level boxes (`inline-block` / `inline-flex` / `inline-grid` / `inline-table`) **cannot be fragmented across CSS columns**, so in paginated mode the tall box overflows the page vertically and every column past the first is clipped. The result: a chapter silently jumps straight to its "Reference materials", skipping a large middle section, and the page counter reads "1 page left in chapter" while most of the chapter is unreachable.

Observed in "System Design Interview – An Insider's Guide: Volume 2" (Chapter 8 `OEBPS/c554.xhtml`): everything after the data-model tables (Search, Scalability, Step 4 – Wrap Up, figures) was unreachable. Diagnostic tell: in column mode `documentElement.scrollHeight` was 7768px against a 632px page.

## Fix

`#demoteUnfragmentableBoxes(availableHeight)`, called from `columnize()` after `setImageSize` (paginated mode only). It has a cheap fast-path — does nothing unless the document overflows its column (`scrollHeight > clientHeight`) — and when it does, demotes any atomic-inline element taller than the column to its fragmentable block-level equivalent (`inline-block→block`, `inline-flex→flex`, `inline-grid→grid`, `inline-table→table`). Idempotent, and short legitimate inline-blocks (e.g. side-by-side figures) are never page-tall so they're untouched. Mirrors the existing over-tall-image clamp in `setImageSize`.

Verified live (full chapter now paginates, references follow the complete content) and with a browser test in the consuming app (readest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)