### PR TITLE
fix(fb2): parse series from title-info sequence element

### DIFF
--- a/fb2.js
+++ b/fb2.js
@@ -235,6 +235,13 @@ export const makeFB2 = async blob => {
     }
     const getDate = el => el?.getAttribute('value') ?? getElementText(el)
     const annotation = $('title-info annotation')
+    // FB2 stores series info as `<sequence name="…" number="…"/>` in title-info
+    const series = $$('title-info > sequence')
+        .map(el => ({
+            name: normalizeWhitespace(el.getAttribute('name')),
+            position: el.getAttribute('number') || undefined,
+        }))
+        .filter(x => x.name)
     book.metadata = {
         title: getElementText($('title-info book-title')),
         identifier: getElementText($('document-info id')),
@@ -247,6 +254,7 @@ export const makeFB2 = async blob => {
             .concat($$('document-info program-used').map(getElementText))
             .map(x => Object.assign(typeof x === 'string' ? { name: x } : x,
                 { role: 'bkp' })),
+        belongsTo: series.length ? { series } : undefined,
         publisher: getElementText($('publish-info publisher')),
         published: getDate($('title-info date')),
         modified: getDate($('document-info date')),


### PR DESCRIPTION
## Problem

FB2 stores series info as `<sequence name="…" number="…"/>` inside `<title-info>`, but `makeFB2` never read it. As a result `book.metadata.belongsTo.series` was always empty, so consumers that derive a series name/index (e.g. Readest's library grouping) had nothing to work with.

Reported downstream at readest/readest#4646 — series stays empty for every FB2 book, and neither "Refresh metadata" nor re-import helps (all paths share this parser).

## Fix

Map `title-info > sequence` into the same `belongsTo.series` shape already produced by the EPUB (`belongs-to-collection`) and comic-book (`ComicInfo.xml`) parsers:

```js
const series = $$('title-info > sequence')
    .map(el => ({
        name: normalizeWhitespace(el.getAttribute('name')),
        position: el.getAttribute('number') || undefined,
    }))
    .filter(x => x.name)
// …
belongsTo: series.length ? { series } : undefined,
```

The child combinator scopes to `title-info`'s own sequences (FB2 allows nested sub-sequences); `position` is left as the raw string to match the existing collection shape.

## Verification

Verified against the file from the issue (`<sequence name="ТБ" number="4"/>`) → `{ name: "ТБ", position: "4" }`, plus a synthetic ASCII fixture, via a unit test in the readest-app suite (full suite green, eslint clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)