### PR TITLE
fix(tts): start reading from the sentence containing the selection

### DIFF
--- a/tts.js
+++ b/tts.js
@@ -451,12 +451,15 @@ export class TTS {
         this.#lastMark = null
         const [doc] = this.#list.find(range_ =>
             range.compareBoundaryPoints(Range.END_TO_START, range_) <= 0)
+        // Pick the mark whose sentence contains the selection: the last mark
+        // that begins at or before it. Taking the first mark beginning at or
+        // after the selection skipped to the next sentence whenever the
+        // selected word was not its sentence's first word.
         let mark
-        for (const [name, range_] of this.#ranges.entries())
-            if (range.compareBoundaryPoints(Range.START_TO_START, range_) <= 0) {
-                mark = name
-                break
-            }
+        for (const [name, range_] of this.#ranges.entries()) {
+            if (range.compareBoundaryPoints(Range.START_TO_START, range_) < 0) break
+            mark = name
+        }
         return this.#speak(doc, ssml => this.#getMarkElement(ssml, mark))
     }
     getLastRange() {


### PR DESCRIPTION
## Problem

`TTS.from(range)` (used by Readest's "Speak from selection" — select a word, then tap the TTS icon) chose the **first** mark whose start was at or after the selection:

```js
if (range.compareBoundaryPoints(Range.START_TO_START, range_) <= 0) { mark = name; break }
```

When the selected word was **not** the first word of its sentence, that sentence's mark starts *before* the selection, so it was skipped and playback began at the **next** sentence. (Selecting the first word of a sentence happened to work, which is why it was intermittent.)

## Fix

Pick the **last** mark that begins at or before the selection — the sentence that actually contains it:

```js
let mark
for (const [name, range_] of this.#ranges.entries()) {
    if (range.compareBoundaryPoints(Range.START_TO_START, range_) < 0) break
    mark = name
}
```

The block-selection (`find` with `END_TO_START`) was already correct and is unchanged.

## Testing

Covered downstream in readest-app (`src/__tests__/document/tts.test.ts`, `from() selection start`): mid-sentence / first-word / last-sentence selections. Verified live: selecting a mid-sentence word now starts at that sentence's head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)