### PR TITLE
feat(fixed-layout): configurable scroll-mode page gap via scroll-gap attribute

### DIFF
--- a/fixed-layout.js
+++ b/fixed-layout.js
@@ -59,6 +59,11 @@ export const restoreScrollModeAnchor = (pages, anchor, maxScrollTop) => {
     return clamp(page.top + page.height * anchor.fraction, 0, maxScrollTop)
 }
 
+export const scrollGapToCss = (value) => {
+    const n = parseFloat(value)
+    return Number.isFinite(n) && n >= 0 ? `${n}px` : null
+}
+
 // Align the SVG overlayer's coord system with the iframe's unscaled content.
 // When the iframe is visually scaled via CSS transform (non-PDF path),
 // getClientRects() inside the iframe returns positions in the iframe's native
@@ -82,7 +87,7 @@ export const applyOverlayerViewBox = (frame, overlayer) => {
 }
 
 export class FixedLayout extends HTMLElement {
-    static observedAttributes = ['zoom', 'scale-factor', 'spread', 'flow']
+    static observedAttributes = ['zoom', 'scale-factor', 'spread', 'flow', 'scroll-gap']
     #root = this.attachShadow({ mode: 'open' })
     #observer = new ResizeObserver(() => this.#render())
     #spreads
@@ -181,7 +186,7 @@ export class FixedLayout extends HTMLElement {
             position: relative;
             flex-shrink: 0;
             overflow: hidden;
-            margin: 4px 0;
+            margin: var(--scroll-page-gap, 4px) 0;
         }
         :host([flow="scrolled"]) .scroll-page iframe {
             pointer-events: none;
@@ -215,6 +220,14 @@ export class FixedLayout extends HTMLElement {
                     this.#render()
                 }
                 break
+            case 'scroll-gap': {
+                const css = scrollGapToCss(value)
+                const anchor = this.#scrollMode ? this.#captureScrollModeAnchor() : null
+                if (css === null) this.style.removeProperty('--scroll-page-gap')
+                else this.style.setProperty('--scroll-page-gap', css)
+                if (anchor) this.#restoreScrollModeAnchor(anchor)
+                break
+            }
         }
     }
     async #createFrame({ index, src: srcOption, detached = false }) {


### PR DESCRIPTION
Makes the fixed-layout **scrolled-mode** inter-page gap configurable, so a host app can render image books (comics / manga / webtoons / PDF) as a seamless edge-to-edge vertical strip.

## Change
- New observed attribute `scroll-gap` (px). `attributeChangedCallback` maps it to a host CSS custom property `--scroll-page-gap` and the rule becomes:
  ```css
  :host([flow="scrolled"]) .scroll-page { margin: var(--scroll-page-gap, 4px) 0; }
  ```
- The handler **captures and restores the scroll anchor** around the change (`#captureScrollModeAnchor` / `#restoreScrollModeAnchor`), so changing the gap mid-strip doesn't jump the reader by N×gap px.
- A small exported pure helper `scrollGapToCss(value)` (`'0' → '0px'`, invalid/empty/negative/null → `null` so the CSS fallback applies).

## Backward compatibility
Fully additive: the `var(--scroll-page-gap, 4px)` fallback and the additive `observedAttributes` entry mean any consumer that never sets `scroll-gap` is byte-identical to before (default 4px).

Used by Readest for "Webtoon Mode" — readest/readest#3647.
