### PR TITLE
fix(pdf): throttle concurrent range reads to avoid WebView OOM

### DIFF
--- a/pdf.js
+++ b/pdf.js
@@ -345,12 +345,33 @@ const parseCalibreSeriesFromXMP = raw => {
     return position ? { name, position } : { name }
 }
 
+// Maximum number of range reads to keep in flight at once. While parsing a
+// large PDF's cross-reference and object streams, pdf.js can request hundreds
+// of byte ranges in a single burst. A real HTTP transport is implicitly
+// throttled by the browser's per-host connection limit (~6); the custom file
+// schemes readest serves these reads through (Android's `rangefile` /
+// `shouldInterceptRequest`, iOS' native file bridge) have no such limit, so
+// firing every request at once floods the native handler and exhausts the
+// WebView's heap, crashing on 50 MB+ PDFs (readest #3470). Throttle here.
+const MAX_CONCURRENT_RANGES = 6
+
 export const makePDF = async file => {
     const transport = new pdfjsLib.PDFDataRangeTransport(file.size, [])
+    // Bound the concurrent range reads instead of dispatching them all at once.
+    let active = 0
+    const queue = []
+    const pump = () => {
+        while (active < MAX_CONCURRENT_RANGES && queue.length) {
+            const [begin, end] = queue.shift()
+            active++
+            file.slice(begin, end).arrayBuffer()
+                .then(chunk => transport.onDataRange(begin, chunk))
+                .finally(() => { active--; pump() })
+        }
+    }
     transport.requestDataRange = (begin, end) => {
-        file.slice(begin, end).arrayBuffer().then(chunk => {
-            transport.onDataRange(begin, chunk)
-        })
+        queue.push([begin, end])
+        pump()
     }
     const pdf = await pdfjsLib.getDocument({
         range: transport,


### PR DESCRIPTION
## Problem

Opening a large PDF makes pdf.js request hundreds of byte ranges in a single burst while it parses the cross-reference and object streams. `makePDF` fulfilled every `requestDataRange` with an un-awaited `file.slice(begin, end).arrayBuffer()`, so all of those reads ran concurrently.

When the file is served through a WebView custom scheme — Android's `rangefile` (`shouldInterceptRequest`) or iOS' native file bridge — each read allocates a native buffer. Firing hundreds simultaneously floods the native handler and exhausts the WebView heap, crashing the app on 50 MB+ PDFs:

```
java.lang.OutOfMemoryError: Failed to allocate ... target footprint 536870912 (512 MB)
  at RustWebViewClient.handleRequest(Native Method)
  at RustWebViewClient.shouldInterceptRequest
```

The official pdf.js viewer doesn't hit this because a real HTTP transport is implicitly throttled by the browser's per-host connection limit (~6); the custom file schemes have no such limit.

## Fix

Bound the in-flight range reads to `MAX_CONCURRENT_RANGES = 6` via a small queue + pump, instead of dispatching every `requestDataRange` immediately.

## Verification

Reproduced and verified live on a Xiaomi 13 (Android 16 / WebView 147) via CDP against a 67 MB / 970-page PDF, replicating `makePDF` against the same vendored pdf.js:

| | before | after |
| --- | --- | --- |
| max concurrent range reads | **753** | **6** |
| doc opens (pages / title / viewport) | ✓ | ✓ (identical) |
| time to open | 1446 ms | 1479 ms (no penalty) |

Throttling has no speed cost because 6 parallel reads already saturate throughput.

Paired with a regression test on the readest side (`foliate-pdf-range-concurrency.test.ts`) that asserts `makePDF` keeps at most 6 range reads in flight.

Ref: readest/readest#3470