### PR TITLE
fix(paginator): keep cover background-image visible under a texture

### DIFF
--- a/paginator.js
+++ b/paginator.js
@@ -347,8 +347,15 @@ export const computeBackgroundSegments = (views, scrollPos, bgSize, inset, conta
 // and the resolved colour otherwise. Shared by scrolled-mode view elements and
 // paginated-mode segments so both modes treat textures identically (readest#4399).
 export const textureAwareBackground = (resolved, hasTexture) => {
-    const isTransparent = !resolved
-        || /^\s*(transparent|rgba\(0,\s*0,\s*0,\s*0\))/.test(resolved)
+    // A page that paints an image (e.g. a cover set via body `background-image`)
+    // is NOT transparent — it should occlude the texture, not be dropped. The
+    // computed `background` shorthand always serializes the transparent
+    // background-*color* first (`rgba(0, 0, 0, 0) url(...) ...`), so the
+    // colour-prefix check below would otherwise misclassify a cover as
+    // transparent and hide it behind the texture (verified on Android WebView).
+    const hasImage = /\burl\(/i.test(resolved ?? '')
+    const isTransparent = !hasImage && (!resolved
+        || /^\s*(transparent|rgba\(0,\s*0,\s*0,\s*0\))/.test(resolved))
     return hasTexture && isTransparent ? '' : resolved
 }
 


### PR DESCRIPTION
## Problem

An EPUB cover page that paints the cover via a `<body>` CSS `background-image` (the EPUB leaves `background-color` transparent and stretches the image with `background-size: 100% 100%`, no `<img>` element) shows the reader's **background texture instead of the cover** on the first page when a texture (e.g. parchment) is active.

Example book: `《商梯》` (Sigil/duokan-style cover xhtml):

```html
<body style="background-repeat:no-repeat;background-attachment:fixed;background-size:100% 100%;background-position:center center;background-image:url(../Images/cover.jpg);">
```

## Root cause

The paginator captures the body background into `view.docBackground` via `getComputedStyle(body).background` (the shorthand), which always serializes the transparent background-**color** first:

```
rgba(0, 0, 0, 0) url("blob:...") no-repeat fixed 50% 50% / 100% 100% ...
```

`textureAwareBackground()` classified that as transparent (its regex only checked the `rgba(0, 0, 0, 0)` / `transparent` prefix). With a texture active it returned `''`, so no background segment was painted and the host texture (`.foliate-viewer::before`) showed through instead of the cover. Without a texture the cover renders fine, so this only reproduces when a texture is enabled.

## Fix

A background that carries an image is not transparent. A full-page cover should occlude the texture, not be dropped. Plain transparent pages still drop their fill so the texture shows through.

## Verification

Verified on a physical Xiaomi 13 (Android 16, WebView 147) via adb + CDP:
- Confirmed `hasTexture` (parchment) + dark mode, host `#background` had 0 segments (cover painted nowhere).
- Confirmed the WebView serializes the shorthand with the image url, and the cover blob loads (1200x1800).
- Painted a test segment with the real cover blob: the cover renders correctly; the fixed `textureAwareBackground` now keeps it while still dropping imageless transparent pages.

Regression test added on the readest side (`paginator-background-segments.test.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)