### PR TITLE
fix(paginator): stretch Duokan fullscreen cover to fill the page

### DIFF
--- a/paginator.js
+++ b/paginator.js
@@ -685,6 +685,10 @@ class View {
                     width: '100%',
                     height: '100%',
                     margin: '0',
+                    // stretch edge-to-edge, ignoring aspect ratio, so the cover
+                    // fills the whole page like Duokan's native full-page render
+                    // (overrides the 'contain' set for all images above)
+                    'object-fit': 'fill',
                 })
                 let ancestor = el.parentElement
                 while (ancestor && ancestor !== doc.body) {
@@ -697,7 +701,7 @@ class View {
                     ancestor = ancestor.parentElement
                 }
                 if (el.localName === 'svg') {
-                    el.setAttribute('preserveAspectRatio', 'xMidYMid meet')
+                    el.setAttribute('preserveAspectRatio', 'none')
                 }
             } else if (pageFullscreen) {
                 // Scrolled mode for a fullscreen-cover doc: undo any absolute


### PR DESCRIPTION
## Summary
Duokan full-page cover documents (`data-duokan-page-fullscreen`) were rendered with `object-fit: contain`, which letterboxes the cover when its aspect ratio doesn't match the page.

This switches the **paginated fullscreen branch** of `setImageSize()` to `object-fit: fill` (and `preserveAspectRatio="none"` for SVG), so the cover stretches edge-to-edge — distorting to fit — like Duokan's native full-page render.

Scoped strictly to the fullscreen branch:
- Ordinary inline images everywhere keep `object-fit: contain`.
- Scrolled-mode Duokan covers keep `contain` bounded by `max-height` (the #4379 flow is untouched — there's no fixed page height to fill in scrolled mode).

## Test
Verified on the readest side: a browser test asserts the fullscreen cover computes `object-fit: fill` (fails as `contain` without this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)