### PR TITLE
fix(pdf): fill page canvas to its box to remove spread spine seam

### DIFF
--- a/pdf.js
+++ b/pdf.js
@@ -158,6 +158,16 @@ const render = async (page, doc, zoom, pageColors) => {
     const canvas = document.createElement('canvas')
     canvas.height = viewport.height
     canvas.width = viewport.width
+    // `canvas.width`/`canvas.height` are the bitmap size and must be integers,
+    // so the fractional `viewport.{width,height}` (= pageSizeCss *
+    // devicePixelRatio) is truncated. The iframe content is displayed scaled by
+    // `1 / devicePixelRatio` (see the `documentElement` transform above), so a
+    // truncated bitmap renders up to ~1 device pixel narrower than the page box,
+    // leaving a one-pixel white seam at the spine of a two-page spread (#4587).
+    // Pin an explicit CSS size to the un-truncated viewport dimensions so the
+    // bitmap scales to fill the page box exactly.
+    canvas.style.width = `${viewport.width}px`
+    canvas.style.height = `${viewport.height}px`
     const canvasContext = canvas.getContext('2d')
     const renderTask = page.render({ canvasContext, viewport, pageColors })
     activeRenderTasks.set(doc, renderTask)


### PR DESCRIPTION
## Problem

In a PDF two-page spread at a fractional `devicePixelRatio` (e.g. Windows display scale 150% → dpr 1.5), a one-pixel white bar appears at the **spine** on certain zoom levels. At 100% (dpr 1) it's absent. Reported in readest/readest#4587.

## Root cause

`render()` sized the page canvas only via its bitmap:

```js
canvas.width = viewport.width   // viewport.width = pageWidthCss * devicePixelRatio
```

A canvas bitmap width must be an integer, so the fractional `viewport.width` is **truncated** (floating-point error often drops a whole pixel: `522 * 1.5` → `782.9999` → `782`). The iframe content is displayed scaled by `1 / devicePixelRatio` (the `documentElement` transform), so the truncated bitmap renders up to ~1 device pixel **narrower** than the page box. The left page's canvas therefore stops short of the spine and exposes the background as a thin seam. (The page flex boxes are always exactly adjacent — the gap is canvas-vs-box, not box-vs-box.)

## Fix

Pin an explicit CSS size to the **un-truncated** viewport dimensions so the bitmap is scaled to fill the page box exactly (displayed width = box width):

```js
canvas.style.width = `${viewport.width}px`
canvas.style.height = `${viewport.height}px`
```

This is the standard pdf.js HiDPI idiom (bitmap = device px, CSS = logical size) that the wrapper had omitted. It generalizes to every page-canvas edge shortfall, across all dpr and render modes.

## Verification

Reproduced live in Chrome forced to `--force-device-scale-factor=1.5` with a US-Letter PDF in spread mode, sweeping window widths:

- **Before:** seams of 0.5–1.0 device px at the spine on several widths (e.g. left-page canvas right edge `761.333` vs spine `762`).
- **After:** `leftCanvasRight === spine` at every swept width (0/21 widths have a seam); spine is seamless.

A regression test is added on the readest side (`pdf-spread-seam.test.ts`) that fails before this change and passes after.