### PR TITLE
fix(fixed-layout): stop double-scrolling the host on wheel over scrolled-mode pages

### DIFF
--- a/fixed-layout.js
+++ b/fixed-layout.js
@@ -720,13 +720,18 @@ export class FixedLayout extends HTMLElement {
                         },
                     },
                 }))
-                // Forward wheel events to host when iframe has pointer-events
-                // (fallback for the brief window after scroll settles)
-                doc.addEventListener('wheel', e => {
-                    // Disable pointer-events immediately so subsequent
-                    // wheel ticks use native scroll
+                // During the brief idle window after scrolling settles the
+                // iframe is interactive (pointer-events: auto), so the first
+                // wheel tick of a new gesture lands on it. The browser already
+                // chains that tick to the host scroller natively (a single
+                // smooth scroll, matching the page margins) — so we must NOT
+                // scroll the host ourselves here, or the manual scroll stacks
+                // on top of the native one and the page jumps twice as far in
+                // an instant lurch (readest#4727). Just drop pointer-events so
+                // the iframe stops intercepting and the rest of the gesture
+                // scrolls the host natively too.
+                doc.addEventListener('wheel', () => {
                     this.#setScrollIframeInteraction(false)
-                    this.scrollBy({ top: e.deltaY, left: e.deltaX, behavior: 'instant' })
                 }, { passive: true })
             }
         } catch (e) {


### PR DESCRIPTION
## Problem

In fixed-layout / PDF **scrolled** mode, a single mouse-wheel notch scrolls the page roughly **twice as far**, in an instant lurch, when the pointer is **over a page**, but a single **smooth** scroll when over the **page margin**. See readest/readest#4727.

## Root cause

`#loadScrollPage` attaches a `{ passive: true }` wheel listener to each page iframe's document that ran:

```js
this.scrollBy({ top: e.deltaY, left: e.deltaX, behavior: 'instant' })
```

The page iframe is `scrolling="no"` + `overflow:hidden`, so the browser **already chains** the wheel to the host scroller natively (a single smooth scroll). The manual `scrollBy` **stacked on top** of that native scroll → ~2× distance, with the `behavior:'instant'` jump preceding the native glide. The iframe is only interactive (`pointer-events:auto`) during the ~150 ms idle window after scrolling settles, so a normally-paced notched wheel lands every notch in that window → every notch doubled.

Margin-hover hits the host directly → only the single native scroll → no doubling.

## Fix

Remove the redundant manual `scrollBy`; keep `#setScrollIframeInteraction(false)` so the iframe stops intercepting and the rest of the gesture also scrolls the host natively. Native scroll-chaining is the single smooth scroll that matches the margin.

## Verification

Reproduced in headless Chromium with a real `mouse.wheel` over a `scrolling="no"` iframe in a scroll container: **240 px over the page vs 120 px over the margin** with the manual scroll; **120 == 120** after removing it. The readest side adds a browser-lane regression test that mounts the real `<foliate-fxl>` element and asserts the JS handler does not move the host scroller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)