### PR TITLE
feat(search): add regex and nearby-words search modes

### DIFF
--- a/search.js
+++ b/search.js
@@ -37,6 +37,33 @@ const makeExcerpt = (strs, { startIndex, startOffset, endIndex, endOffset }) => 
     return { pre, match, post }
 }
 
+// Cumulative character offsets of the joined `strs`, so a flat offset into
+// `strs.join('')` can be mapped back to a (node index, in-node offset) pair.
+const buildCum = strs => {
+    const cum = [0]
+    for (let i = 0; i < strs.length; i++) cum.push(cum[i] + strs[i].length)
+    return cum
+}
+
+// Largest node i with cum[i] <= offset; clamps the end-of-text offset to the
+// last node's end. Works for both range start and (exclusive) end positions.
+const nodeAt = (cum, offset) => {
+    let lo = 0, hi = cum.length - 2
+    if (hi < 0) return { index: 0, offset: 0 }
+    while (lo < hi) {
+        const mid = (lo + hi + 1) >> 1
+        if (cum[mid] <= offset) lo = mid
+        else hi = mid - 1
+    }
+    return { index: lo, offset: offset - cum[lo] }
+}
+
+const rangeFromFlat = (cum, start, end) => {
+    const s = nodeAt(cum, start)
+    const e = nodeAt(cum, end)
+    return { startIndex: s.index, startOffset: s.offset, endIndex: e.index, endOffset: e.offset }
+}
+
 const simpleSearch = function* (strs, query, options = {}) {
     const { locales = 'en', sensitivity } = options
     const matchCase = sensitivity === 'variant'
@@ -117,7 +144,144 @@ const segmenterSearch = function* (strs, query, options = {}) {
     }
 }
 
+// Calibre-parity regex mode (#4560). Runs a JS RegExp over the joined text and
+// maps each match back to a node range. Note: RegExp.exec is synchronous, so a
+// catastrophic pattern can still stall this pass — true interruption (a Web
+// Worker) is left to a follow-up; here we only cap match count and reject
+// invalid patterns. The caller surfaces INVALID_REGEX as a calm inline error.
+const MAX_REGEX_MATCHES = 10000
+const regexSearch = function* (strs, query, options = {}) {
+    const { matchCase } = options
+    const flags = matchCase ? 'g' : 'gi'
+    let re
+    try {
+        re = new RegExp(query, flags + 'u')
+    } catch {
+        // Some patterns are valid only without the unicode flag; fall back.
+        try {
+            re = new RegExp(query, flags)
+        } catch (e) {
+            const err = new Error(`Invalid regular expression: ${e.message}`)
+            err.code = 'INVALID_REGEX'
+            throw err
+        }
+    }
+    const haystack = strs.join('')
+    const cum = buildCum(strs)
+    let count = 0
+    let m
+    while ((m = re.exec(haystack)) !== null) {
+        if (m[0].length === 0) {
+            // zero-width match: advance to avoid an infinite loop
+            re.lastIndex = m.index + 1
+            continue
+        }
+        const range = rangeFromFlat(cum, m.index, m.index + m[0].length)
+        yield { range, excerpt: makeExcerpt(strs, range) }
+        if (++count >= MAX_REGEX_MATCHES) break
+    }
+}
+
+// Segmented excerpt for nearby-words: emphasizes only the matched words inside
+// the cluster window, leaving the gap text un-emphasized. `pre`/`match`/`post`
+// stay populated for consumers that don't render segments.
+const makeNearbyExcerpt = (haystack, matched) => {
+    const clusterStart = matched[0].start
+    const clusterEnd = matched[matched.length - 1].end
+    const trimmedStart = normalizeWhitespace(haystack.slice(0, clusterStart)).trimStart()
+    const trimmedEnd = normalizeWhitespace(haystack.slice(clusterEnd)).trimEnd()
+    const ellipsisPre = trimmedStart.length < CONTEXT_LENGTH ? '' : '…'
+    const ellipsisPost = trimmedEnd.length < CONTEXT_LENGTH ? '' : '…'
+    const pre = `${ellipsisPre}${trimmedStart.slice(-CONTEXT_LENGTH)}`
+    const post = `${trimmedEnd.slice(0, CONTEXT_LENGTH)}${ellipsisPost}`
+    const segments = []
+    let cursor = clusterStart
+    for (const o of matched) {
+        if (o.start > cursor) {
+            const gap = normalizeWhitespace(haystack.slice(cursor, o.start))
+            if (gap) segments.push({ text: gap, emphasized: false })
+        }
+        segments.push({ text: normalizeWhitespace(haystack.slice(o.start, o.end)), emphasized: true })
+        cursor = o.end
+    }
+    const match = normalizeWhitespace(haystack.slice(clusterStart, clusterEnd))
+    return { pre, match, post, segments }
+}
+
+// Calibre-parity nearby-words mode (#4560): matches places where all of the
+// query's distinct whole words occur within `nearbyWords` words of each other.
+// Distance is measured in words (not characters) and comes from the option, not
+// from the query string, so trailing numbers stay literal search words.
+const nearbyWordsSearch = function* (strs, query, options = {}) {
+    const { locales = 'en', sensitivity = 'base', nearbyWords = 10 } = options
+    const queryWords = []
+    for (const w of query.split(/\s+/).filter(Boolean)) if (!queryWords.includes(w)) queryWords.push(w)
+    if (queryWords.length < 2) {
+        const err = new Error('Nearby words search needs at least two words')
+        err.code = 'NEARBY_NEEDS_TWO_WORDS'
+        throw err
+    }
+    let segmenter, collator
+    try {
+        segmenter = new Intl.Segmenter(locales, { usage: 'search', granularity: 'word' })
+        collator = new Intl.Collator(locales, { sensitivity })
+    } catch (e) {
+        console.warn(e)
+        segmenter = new Intl.Segmenter('en', { usage: 'search', granularity: 'word' })
+        collator = new Intl.Collator('en', { sensitivity })
+    }
+    const haystack = strs.join('')
+    const cum = buildCum(strs)
+    const K = queryWords.length
+
+    // Word occurrences of any query word, tagged with a global word index.
+    const occ = []
+    let wordIndex = -1
+    for (const seg of segmenter.segment(haystack)) {
+        if (!seg.isWordLike) continue
+        wordIndex++
+        for (let q = 0; q < K; q++) {
+            if (collator.compare(queryWords[q], seg.segment) === 0) {
+                occ.push({ wordIndex, qIdx: q, start: seg.index, end: seg.index + seg.segment.length })
+                break
+            }
+        }
+    }
+
+    // Smallest window covering all K distinct query words, two-pointer scan.
+    const have = new Array(K).fill(0)
+    let distinct = 0
+    let lo = 0
+    const windows = []
+    for (let hi = 0; hi < occ.length; hi++) {
+        if (have[occ[hi].qIdx]++ === 0) distinct++
+        let minimal = null
+        while (distinct === K) {
+            minimal = { lo, hi }
+            if (--have[occ[lo].qIdx] === 0) distinct--
+            lo++
+        }
+        if (minimal && occ[minimal.hi].wordIndex - occ[minimal.lo].wordIndex <= nearbyWords)
+            windows.push(minimal)
+    }
+
+    // One cluster per window; suppress windows overlapping an already-emitted one.
+    let lastHi = -1
+    for (const w of windows) {
+        if (w.lo <= lastHi) continue
+        lastHi = w.hi
+        const matched = occ.slice(w.lo, w.hi + 1)
+        const excerpt = makeNearbyExcerpt(haystack, matched)
+        const range = rangeFromFlat(cum, matched[0].start, matched[matched.length - 1].end)
+        const subRanges = matched.map(o => rangeFromFlat(cum, o.start, o.end))
+        yield { range, excerpt, subRanges }
+    }
+}
+
 export const search = (strs, query, options) => {
+    const { mode } = options
+    if (mode === 'regex') return regexSearch(strs, query, options)
+    if (mode === 'nearby-words') return nearbyWordsSearch(strs, query, options)
     const { granularity = 'grapheme', sensitivity = 'base' } = options
     if (!Intl?.Segmenter || granularity === 'grapheme'
     && (sensitivity === 'variant' || sensitivity === 'accent'))
@@ -126,12 +290,16 @@ export const search = (strs, query, options) => {
 }
 
 export const searchMatcher = (textWalker, opts) => {
-    const { defaultLocale, matchCase, matchDiacritics, matchWholeWords, acceptNode } = opts
+    const { defaultLocale, matchCase, matchDiacritics, matchWholeWords, mode, nearbyWords, acceptNode } = opts
+    const effectiveMode = mode ?? (matchWholeWords ? 'whole-words' : 'contains')
     return function* (doc, query) {
         const iter = textWalker(doc, function* (strs, makeRange) {
             for (const result of search(strs, query, {
+                mode: effectiveMode,
+                nearbyWords,
+                matchCase,
                 locales: doc.body.lang || doc.documentElement.lang || defaultLocale || 'en',
-                granularity: matchWholeWords ? 'word' : 'grapheme',
+                granularity: effectiveMode === 'whole-words' ? 'word' : 'grapheme',
                 sensitivity: matchDiacritics && matchCase ? 'variant'
                 : matchDiacritics && !matchCase ? 'accent'
                 : !matchDiacritics && matchCase ? 'case'
@@ -139,6 +307,8 @@ export const searchMatcher = (textWalker, opts) => {
             })) {
                 const { startIndex, startOffset, endIndex, endOffset } = result.range
                 result.range = makeRange(startIndex, startOffset, endIndex, endOffset)
+                if (result.subRanges) result.subRanges = result.subRanges.map(
+                    r => makeRange(r.startIndex, r.startOffset, r.endIndex, r.endOffset))
                 yield result
             }
         }, acceptNode)

--- a/view.js
+++ b/view.js
@@ -585,18 +585,25 @@ export class View extends HTMLElement {
     goRight() {
         return this.book.dir === 'rtl' ? this.prev() : this.next()
     }
+    // A matcher result carries a primary `range` (nav/excerpt anchor) and, for
+    // nearby-words, per-word `subRanges` to highlight each matched word.
+    #toSearchMatch(index, { range, excerpt, subRanges }) {
+        const cfi = this.getCFI(index, range)
+        if (subRanges?.length)
+            return { cfi, cfis: subRanges.map(r => this.getCFI(index, r)), excerpt }
+        return { cfi, excerpt }
+    }
     async * #searchSection(matcher, query, index) {
         const doc = await this.book.sections[index].createDocument()
-        for (const { range, excerpt } of matcher(doc, query))
-            yield { cfi: this.getCFI(index, range), excerpt }
+        for (const match of matcher(doc, query))
+            yield this.#toSearchMatch(index, match)
     }
     async * #searchBook(matcher, query) {
         const { sections } = this.book
         for (const [index, { createDocument }] of sections.entries()) {
             if (!createDocument) continue
             const doc = await createDocument()
-            const subitems = Array.from(matcher(doc, query), ({ range, excerpt }) =>
-                ({ cfi: this.getCFI(index, range), excerpt }))
+            const subitems = Array.from(matcher(doc, query), match => this.#toSearchMatch(index, match))
             const progress = (index + 1) / sections.length
             yield { progress }
             if (subitems.length) yield { index, subitems }
@@ -618,7 +625,7 @@ export class View extends HTMLElement {
                         yield { progress }
                         yield { index: result.index, subitems: result.subitems }
                     } else {
-                        yield { cfi: result.cfi, excerpt: result.excerpt }
+                        yield { cfi: result.cfi, cfis: result.cfis, excerpt: result.excerpt }
                     }
                 }
             })()
@@ -627,14 +634,27 @@ export class View extends HTMLElement {
                 : this.#searchBook(matcher, query)
 
         const list = []
+        const seen = new Set()
         this.#searchResults.set(index, list)
+        // Add one annotation per unique CFI (a nearby-words match carries several
+        // via `cfis`); dedupe so overlapping CFIs don't collide in #searchResults.
+        const addHighlights = (cfis, sink, sinkSeen) => {
+            for (const cfi of cfis) {
+                if (sinkSeen.has(cfi)) continue
+                sinkSeen.add(cfi)
+                const item = { value: SEARCH_PREFIX + cfi }
+                sink.push(item)
+                this.addAnnotation(item)
+            }
+        }
 
         for await (const result of iter) {
             if (result.subitems){
-                const list = result.subitems
-                    .map(({ cfi }) => ({ value: SEARCH_PREFIX + cfi }))
-                this.#searchResults.set(result.index, list)
-                for (const item of list) this.addAnnotation(item)
+                const sectionList = []
+                const sectionSeen = new Set()
+                for (const item of result.subitems)
+                    addHighlights(item.cfis ?? [item.cfi], sectionList, sectionSeen)
+                this.#searchResults.set(result.index, sectionList)
                 yield {
                     index: result.index,
                     label: this.#tocProgress?.getProgress(result.index)?.label ?? '',
@@ -642,11 +662,7 @@ export class View extends HTMLElement {
                 }
             }
             else {
-                if (result.cfi) {
-                    const item = { value: SEARCH_PREFIX + result.cfi }
-                    list.push(item)
-                    this.addAnnotation(item)
-                }
+                if (result.cfi) addHighlights(result.cfis ?? [result.cfi], list, seen)
                 yield result
             }
         }


### PR DESCRIPTION
Adds two Calibre-parity search modes to the matcher, used by readest/readest#4560.

## Changes
- `search.js`: a `mode` dispatch in `search()` / `searchMatcher()`:
  - **regex** (`regexSearch`): JS `RegExp` over the joined section text, mapped back to node ranges. Case flag from `matchCase`, unicode-flag fallback, zero-width matches skipped, match count capped. Invalid patterns raise a typed `INVALID_REGEX` error for the caller to surface calmly.
  - **nearby-words** (`nearbyWordsSearch`): whole words occurring within N words of each other (distance from the `nearbyWords` option, default 10), found via a two-pointer smallest-window scan over per-word occurrences. Emits one cluster per non-overlapping window with per-word `subRanges` and a segmented excerpt that emphasizes only the matched words.
  - Existing `contains` / `whole-words` paths are unchanged.
- `view.js`: threads `mode`/`nearbyWords` through to the matcher, mints a primary CFI plus per-word CFIs for nearby matches, and dedupes search annotations so overlapping CFIs don't collide.

Backward compatible: callers that don't pass `mode` get today's behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)