### PR TITLE
fix(paginator): add gpu-composite opt-in to keep the GPU page-turn path

### DIFF
--- a/paginator.js
+++ b/paginator.js
@@ -1080,6 +1080,18 @@ export class Paginator extends HTMLElement {
         #container.vertical {
             flex-direction: column;
         }
+        /* Apple WebKit (iOS/macOS) composites large, persistent layers without
+           the ~1s Blink freeze Android Chromium hits at high DPR (the reason
+           these promotion hints were dropped and rafAnimateScroll was added).
+           When the host opts in, restore persistent compositor layers for the
+           container and each view so the GPU cssAnimateScroll page-turn stays
+           smooth on 120Hz ProMotion instead of promoting a layer on-demand
+           every turn (readest#4768). Paginated mode only; scrolled mode does
+           its own compositing below. */
+        :host([gpu-composite]:not([flow="scrolled"])) #container,
+        :host([gpu-composite]:not([flow="scrolled"])) #container > * {
+            transform: translateZ(0);
+        }
         :host([flow="scrolled"]) #container {
             grid-column: 2 / 5;
             grid-row: 1 / -1;
@@ -1930,8 +1942,12 @@ export class Paginator extends HTMLElement {
             // For a large section the CSS-transform animation blocks the UI while
             // Blink composites the oversized layer; animate the native scroll
             // offset instead (incremental/tiled, like a swipe), keeping the
-            // per-page backgrounds synced each frame.
-            if (this.#renderedViewSize > RAF_ANIMATE_SCROLL_THRESHOLD) {
+            // per-page backgrounds synced each frame. Hosts that composite large
+            // layers without that freeze (Apple WebKit, via the gpu-composite
+            // opt-in) skip this main-thread fallback and keep the smooth GPU
+            // cssAnimateScroll path even for large sections (readest#4768).
+            if (!this.hasAttribute('gpu-composite')
+                && this.#renderedViewSize > RAF_ANIMATE_SCROLL_THRESHOLD) {
                 return rafAnimateScroll(startPosition, offset, 300, easeOutQuad, x => {
                     this.#container[this.scrollProp] = x
                     if (!this.scrolled) this.#replaceBackground()


### PR DESCRIPTION
## Why

The large-section `rafAnimateScroll` fallback (commit `c1c7315`) and the removal of the persistent compositor-layer hints (`transform: translateZ(0)` on `#container` and each view) were added to avoid a ~1s Blink freeze on Android Chromium when compositing an oversized layer at high DPR.

On **Apple WebKit (iOS/macOS)** those layers composite fine. There the two changes only cost smoothness:

- large-section turns animate `container.scrollLeft` on the **main thread** every frame (plus a per-frame `#replaceBackground()`), and
- every turn promotes a layer **on-demand** via transient `will-change` instead of using a persistent one.

On 120Hz ProMotion devices (e.g. iPhone 17 Pro) this surfaces as occasional page-turn stutter. See readest/readest#4768.

## What

Add a `gpu-composite` host attribute. When the host sets it:

1. Restore persistent compositor layers for the paginated `#container` and each view (paginated mode only; scrolled-mode compositing is untouched).
2. Skip the `rafAnimateScroll` fallback so large sections keep the smooth GPU `cssAnimateScroll` path.

Hosts that do not set the attribute are completely unchanged, so the Android freeze fix stays in force. Readest opts iOS in via the companion PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)