### PR TITLE
fix(fixed-layout): fix spread spine seam and zoomed-out blank page

### DIFF
--- a/fixed-layout.js
+++ b/fixed-layout.js
@@ -131,13 +131,14 @@ export const computePaginatedScroll = ({ elementWidth, containerWidth, scrollTop
 // and the reader background bleeds through as a thin white seam. Pulling the
 // top-most (right) page onto the left by exactly one device pixel makes each
 // soft edge sit over the neighbour's opaque content instead of the background.
-// Returns 0 for layouts with no touching spine (single/centred/portrait page, a
-// blank-padded slot, or a sub-100% zoom where pages shrink inside their boxes).
+// Returns 0 for layouts with no touching spine (single/centred/portrait page or
+// a blank-padded slot). The pages stay adjacent at every zoom, so the overlap
+// applies at sub-100% zoom too.
 export const computeSpreadSpineOverlap = ({
     center = false, portrait = false, leftBlank = false, rightBlank = false,
-    zoomedOut = false, devicePixelRatio = 1,
+    devicePixelRatio = 1,
 } = {}) => {
-    if (center || portrait || leftBlank || rightBlank || zoomedOut) return 0
+    if (center || portrait || leftBlank || rightBlank) return 0
     return -1 / (devicePixelRatio || 1)
 }
 
@@ -474,6 +475,13 @@ export class FixedLayout extends HTMLElement {
             }
             const iframeScale = onZoom ? scale : 1
             const zoomedOut = this.#scaleFactor < 1.0
+            // Centering a zoomed-out page inside its box only works for the PDF
+            // path, whose iframe is natively sized to the (scaled) box. Non-PDF
+            // fixed layout keeps the iframe at its native size and shrinks it
+            // with `transform: scale`, so flex-centering the un-scaled iframe
+            // pushes it out of view and blanks the page (#4857). Keep those in
+            // normal block flow at every zoom.
+            const centerInBox = zoomedOut && onZoom
             Object.assign(iframe.style, {
                 width: `${width * iframeScale}px`,
                 height: `${height * iframeScale}px`,
@@ -485,10 +493,10 @@ export class FixedLayout extends HTMLElement {
                 width: `${(width ?? blankWidth) * scale}px`,
                 height: `${(height ?? blankHeight) * scale}px`,
                 flexShrink: '0',
-                display: zoomedOut ? 'flex' : 'block',
-                marginBlock: zoomedOut ? undefined : 'auto',
-                alignItems: zoomedOut ? 'center' : undefined,
-                justifyContent: zoomedOut ? 'center' : undefined,
+                display: centerInBox ? 'flex' : 'block',
+                marginBlock: centerInBox ? undefined : 'auto',
+                alignItems: centerInBox ? 'center' : undefined,
+                justifyContent: centerInBox ? 'center' : undefined,
                 ...styles,
             })
             if (portrait && frame !== target) {
@@ -552,7 +560,6 @@ export class FixedLayout extends HTMLElement {
                 portrait,
                 leftBlank: Boolean(left.blank),
                 rightBlank: Boolean(right.blank),
-                zoomedOut: this.#scaleFactor < 1.0,
                 devicePixelRatio: window.devicePixelRatio || 1,
             })
             const leftDimensions = transform({frame: left, styles: { marginInlineStart: 'auto' }})

--- a/fixed-layout.js
+++ b/fixed-layout.js
@@ -123,6 +123,24 @@ export const computePaginatedScroll = ({ elementWidth, containerWidth, scrollTop
     scrollTop: pageTurn ? 0 : scrollTop,
 })
 
+// Visual shift (CSS px) to apply to the right page of a two-page spread to hide
+// the one-pixel white spine seam (#4857). The two page iframes are independent
+// compositor layers, each scaled by a (usually non-integer) factor. At a
+// fractional devicePixelRatio the spine between them lands on a fractional
+// device pixel, so each layer's edge there is anti-aliased against transparency
+// and the reader background bleeds through as a thin white seam. Pulling the
+// top-most (right) page onto the left by exactly one device pixel makes each
+// soft edge sit over the neighbour's opaque content instead of the background.
+// Returns 0 for layouts with no touching spine (single/centred/portrait page, a
+// blank-padded slot, or a sub-100% zoom where pages shrink inside their boxes).
+export const computeSpreadSpineOverlap = ({
+    center = false, portrait = false, leftBlank = false, rightBlank = false,
+    zoomedOut = false, devicePixelRatio = 1,
+} = {}) => {
+    if (center || portrait || leftBlank || rightBlank || zoomedOut) return 0
+    return -1 / (devicePixelRatio || 1)
+}
+
 // Align the SVG overlayer's coord system with the iframe's unscaled content.
 // When the iframe is visually scaled via CSS transform (non-PDF path),
 // getClientRects() inside the iframe returns positions in the iframe's native
@@ -526,8 +544,22 @@ export class FixedLayout extends HTMLElement {
             this.#isOverflowX = width > containerWidth
             this.#isOverflowY = height > containerHeight
         } else {
+            // Hide the 1px white spine seam on a two-page spread by overlapping
+            // the right page onto the left by one device pixel (#4857). Always
+            // set `transform` (to 'none' when not overlapping) so a stale shift
+            // from a previous render is cleared when the layout changes.
+            const overlapX = computeSpreadSpineOverlap({
+                portrait,
+                leftBlank: Boolean(left.blank),
+                rightBlank: Boolean(right.blank),
+                zoomedOut: this.#scaleFactor < 1.0,
+                devicePixelRatio: window.devicePixelRatio || 1,
+            })
             const leftDimensions = transform({frame: left, styles: { marginInlineStart: 'auto' }})
-            const rightDimensions = transform({frame: right, styles: { marginInlineEnd: 'auto' }})
+            const rightDimensions = transform({frame: right, styles: {
+                marginInlineEnd: 'auto',
+                transform: overlapX ? `translateX(${overlapX}px)` : 'none',
+            }})
             if (!leftDimensions || !rightDimensions) return renderPromises
             const {width: leftWidth, height: leftHeight, containerWidth, containerHeight} = leftDimensions
             const {width: rightWidth, height: rightHeight} = rightDimensions


### PR DESCRIPTION
Two rendering bugs in fixed-layout (EPUB and PDF) two-page spreads.

## 1. 1px white spine seam (readest/readest#4857)

At a fractional `devicePixelRatio` (e.g. Windows 150% display scale, dpr 1.5) a 1px white seam appears down the middle at the spine, for both EPUB and PDF. It comes and goes with zoom, the signature of a sub-pixel rasterization issue.

**Cause:** the two page iframes are independent compositor layers, each scaled by a (usually non-integer) factor. At a fractional dpr the spine between them lands on a fractional *device* pixel, so each layer's edge there is anti-aliased against transparency and the reader background bleeds through. This is a different mechanism from the earlier canvas-truncation seam: filling the page canvas to its box does not help, because the softness comes from *scaling the layer*, not from content stopping short of its box.

**Fix:** overlap the top-most (right) page onto the left by exactly one device pixel, so each soft edge sits over the neighbour's opaque content instead of over the background. Visual-only `translateX(-1/dpr px)` on the right page element; skipped for single/centred/portrait/blank spreads.

## 2. Zoomed-out non-PDF pages render blank

Below 100% zoom, non-PDF fixed-layout pages rendered blank (surfaced while testing fix #1).

**Cause:** the zoom-out centering (added for PDF in "Align PDF center on the page when zoomed out") switches the page box to `flex` and centers the iframe. The PDF iframe is natively sized to the scaled box, so centering is correct; but a non-PDF iframe keeps its native size and is shrunk with `transform: scale`, so flex-centering pushed the un-scaled iframe out of view.

**Fix:** gate the centering on the PDF path (`onZoom`) and keep non-PDF pages in normal block flow at every zoom, which fills the box correctly via the transform. Because non-PDF pages now stay adjacent at every zoom, the spine overlap applies at sub-100% zoom too.

## Verification

- Reproduced the seam at dpr 1.5 with Playwright: the spine pixel goes from blended-toward-white `(191,223,255)` to solid page color with the overlap.
- Verified the real reader in Chrome: EPUB fixed-layout renders correctly and seam-free at 50/80/100/130% zoom; PDF path (`onZoom`) behaviour is unchanged.
- Unit test for `computeSpreadSpineOverlap` in the readest app repo.

Fixes readest/readest#4857.
