### PR TITLE
feat(tts): export getSentences for external sentence enumeration

### DIFF
--- a/tts.js
+++ b/tts.js
@@ -263,6 +263,21 @@ function* getBlocks(doc, nodeFilter) {
     }
 }
 
+// Enumerate every TTS segment of the document in order without touching any
+// TTS instance state. blockIndex/markName match what a TTS instance produces
+// for the same granularity, so callers (e.g. a playback timeline) can
+// correlate the enumeration with live marks and use each range with from().
+export function* getSentences(doc, textWalker, nodeFilter, granularity = 'sentence') {
+    let blockIndex = 0
+    for (const range of getBlocks(doc, nodeFilter)) {
+        const lang = getLang(range.commonAncestorContainer)
+        const segmenter = getSegmenter(lang, granularity)
+        for (const [name, segRange] of textWalker(range, segmenter, nodeFilter))
+            yield { blockIndex, markName: name, range: segRange }
+        blockIndex++
+    }
+}
+
 class ListIterator {
     #arr = []
     #iter


### PR DESCRIPTION
Adds an additive `getSentences(doc, textWalker, nodeFilter, granularity)` generator export to `tts.js` that enumerates every TTS segment of a document in order, yielding `{ blockIndex, markName, range }` per sentence.

It reuses the existing `getBlocks` + `getSegmenter` machinery with the same walker/filter/granularity as a live TTS instance, so callers can correlate the enumeration 1:1 with the marks playback produces (mark names restart per block, matching `getFragmentWithMarks`). No changes to the `TTS` class or any existing export.

Consumed by readest's TTS section timeline (position/duration/seek for the reading-aloud scrubber): readest/readest PR to follow, which pins its submodule to this commit. This PR must merge first so the pinned SHA resolves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)