### PR TITLE
feat(epub): parse calibre custom columns from OPF user metadata

### DIFF
--- a/epub.js
+++ b/epub.js
@@ -172,6 +172,47 @@ const getPropertyURL = (value, prefixes) => {
     return baseURL ? baseURL + reference : null
 }
 
+// See the call site in getMetadata() for the two calibre encodings this reads.
+const getCalibreUserMetadata = (metaEls, legacyMeta) => {
+    // calibre's to_json wraps non-JSON types; only datetime appears in columns
+    const fromJSON = x => x?.__class__ === 'datetime.datetime' ? x.__value__ : x
+    const isEmpty = (value, datatype) => value == null || value === ''
+        || Array.isArray(value) && !value.length
+        // calibre can't distinguish these from unset, and neither can we
+        || datatype === 'datetime' && String(value).startsWith('0101-01-01')
+        || datatype === 'rating' && !value
+    const columns = []
+    const add = (key, fm) => {
+        if (!key?.startsWith('#') || typeof fm !== 'object' || !fm) return
+        const datatype = fm.datatype ?? 'text'
+        const value = fromJSON(fm['#value#'])
+        if (isEmpty(value, datatype)) return
+        const extra = fromJSON(fm['#extra#'])
+        const label = key.slice(1)
+        columns.push({
+            label,
+            name: typeof fm.name === 'string' && fm.name ? fm.name : label,
+            datatype, value,
+            ...extra != null ? { extra } : {},
+        })
+    }
+    for (const el of metaEls ?? []) {
+        if (el.getAttribute('property')?.toLowerCase() !== 'calibre:user_metadata') continue
+        try {
+            for (const [key, fm] of Object.entries(JSON.parse(getElementText(el))))
+                add(key, fm)
+        } catch {}
+    }
+    if (!columns.length)
+        for (const [name, content] of Object.entries(legacyMeta ?? {})) {
+            if (!name.startsWith('calibre:user_metadata:')) continue
+            try {
+                add(name.slice('calibre:user_metadata:'.length), JSON.parse(content))
+            } catch {}
+        }
+    return columns.length ? columns : null
+}
+
 const getMetadata = opf => {
     const { $ } = childGetter(opf, NS.OPF)
     const $metadata = $(opf.documentElement, 'metadata')
@@ -307,6 +348,19 @@ const getMetadata = opf => {
     tidy(metadata)
     if (metadata.altIdentifier === metadata.identifier)
         delete metadata.altIdentifier
+    // Calibre embeds its custom columns ("user metadata") when polishing or
+    // sending books. Two encodings (see calibre's opf2.py/opf3.py):
+    //   OPF 2: <meta name="calibre:user_metadata:#label" content="{json}"/> per column
+    //   OPF 3: a single <meta property="calibre:user_metadata"> whose text is
+    //          a JSON dict of all columns keyed by "#label"; calibre prefers
+    //          this form over the legacy metas when both are present
+    // The column value lives in `#value#` (series index in `#extra#`);
+    // datetimes are wrapped as {"__class__": "datetime.datetime",
+    // "__value__": <ISO>} with 0101-01-01 meaning unset. Embedded files carry
+    // every column of the library, so empty values are dropped here. Must run
+    // after tidy(), which would otherwise collapse single-element value arrays.
+    const calibreColumns = getCalibreUserMetadata(els.meta, legacyMeta)
+    if (calibreColumns) metadata.calibreColumns = calibreColumns
 
     const rendition = {}
     const media = {}


### PR DESCRIPTION
## Summary

Calibre embeds its custom columns ("user metadata") into the OPF when polishing or sending books, and the Readest calibre plugin embeds them on push. This parses them into `metadata.calibreColumns` so the app can surface them (readest/readest#4811).

Two encodings exist (see calibre's `opf2.py`/`opf3.py`):
- **OPF 2**: one `<meta name="calibre:user_metadata:#label" content="{json}"/>` element per column
- **OPF 3**: a single `<meta property="calibre:user_metadata">` element whose text is a JSON dict of all columns keyed by `#label`; calibre prefers this form over the legacy metas when both are present, and so does this parser

Each parsed column carries `label`, display `name`, `datatype`, `value` (array for multi-value columns), and `extra` (series index). Calibre's JSON datetime wrapper (`{"__class__": "datetime.datetime", "__value__": ...}`) is unwrapped, and unset values are dropped at parse time (embedded files carry every column of the library, including `0101-01-01` placeholder dates and rating 0).

Notes:
- The OPF 3 form is matched on the raw `property` attribute (always literally `calibre:user_metadata`) rather than the prefix-resolved URL, since calibre's prefix (`https://calibre-ebook.com`) concatenates ambiguously.
- Runs after `tidy()` so single-element value arrays stay arrays.
- Malformed column JSON and non-`#` names are skipped silently, matching calibre's tolerant reader.

## Testing

Covered by unit tests in the readest app (`src/__tests__/foliate-calibre-user-metadata.test.ts`) exercising both encodings, datetime unwrapping, empty-value dropping, malformed JSON, and OPF 3 precedence; verified end-to-end against a real calibre-embedded EPUB from the issue reporter (11 library columns, 7 populated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)