### PR TITLE
fix(pdf): divide out OS font scaling so text layer matches the canvas

### DIFF
--- a/pdf.js
+++ b/pdf.js
@@ -6,6 +6,27 @@ pdfjsLib.GlobalWorkerOptions.workerSrc = pdfjsPath('pdf.worker.min.mjs')
 
 const fetchText = async url => await (await fetch(url)).text()
 
+// The OS accessibility "font size" setting scales every piece of WebView-rendered
+// text (including this transparent selection/highlight text layer) but leaves the
+// page's canvas bitmap untouched. Only the glyph *size* (a font-size) is scaled;
+// the text layer's positions are percentages of the `--total-scale-factor`-sized
+// container and are not. Left uncorrected the glyphs render `fontScale`x larger
+// than the ones baked into the canvas, so selection and highlight rectangles
+// overshoot the text into the blank margins and sit too low (readest #4480).
+// Measure the scale here so render() can divide it back out of the glyph-size
+// lever only. offsetHeight of a 100px/line-height-1 box reflects the OS font
+// scaling but not devicePixelRatio or CSS transforms, so it isolates it.
+const getFontScale = doc => {
+    const probe = doc.createElement('div')
+    probe.style.cssText = 'position:absolute;left:-9999px;top:0;visibility:hidden;'
+        + 'font-size:100px;line-height:1;text-size-adjust:none;-webkit-text-size-adjust:none'
+    probe.textContent = 'x'
+    doc.body.append(probe)
+    const fontScale = probe.offsetHeight / 100
+    probe.remove()
+    return fontScale > 0 ? fontScale : 1
+}
+
 let textLayerBuilderCSS = null
 let annotationLayerBuilderCSS = null
 
@@ -218,6 +239,14 @@ const render = async (page, doc, zoom, pageColors) => {
 
     // Bail out if superseded after async text layer render
     if (renderGenerations.get(doc) !== generation) return
+
+    // Counteract the OS font-size accessibility scaling on the text layer's glyph
+    // size only (see getFontScale). `--text-scale-factor` feeds `font-size` and
+    // nothing else, so dividing it leaves positions (which scale with
+    // `--total-scale-factor`) aligned with the canvas at any font-size setting.
+    const fontScale = getFontScale(doc)
+    if (fontScale !== 1) container.style.setProperty('--text-scale-factor',
+        `calc(var(--total-scale-factor) * var(--min-font-size) / ${fontScale})`)
 
     // hide "offscreen" canvases appended to document when rendering text layer
     // https://github.com/mozilla/pdf.js/blob/642b9a5ae67ef642b9a8808fd9efd447e8c350e2/web/pdf_viewer.css#L51-L58


### PR DESCRIPTION
## Problem

readest/readest#4480: on some Android devices PDF text selection and highlighting is misplaced — the selection rectangles bleed into the blank page margins and sit too low. It reproduced on a Galaxy Tab A8 but not on a Galaxy S21 or on desktop.

## Root cause

It is the **OS "font size" accessibility setting**, not the WebView version or the device pixel ratio.

The OS font scale multiplies every piece of WebView-rendered *text* — including this transparent text layer that backs selection/highlighting — but leaves the *canvas* page bitmap untouched. Crucially, it only scales the glyph **size** (a `font-size`); the text layer's **positions** are percentages of the `--total-scale-factor`-sized container and are not affected. So the transparent glyphs render `fontScale`× larger than the ones baked into the canvas, and the native `::selection` boxes overshoot the text. The Tab A8 (a tablet) had an enlarged system font size; the S21 was at the default.

Ruled out during investigation: WebView version (the Tab A8 was on WebView **148**, newer than the working S21's 147 and a WebView-124 emulator, all fine at the default font scale) and devicePixelRatio (the paginator's fit-width `zoom` keeps `--total-scale-factor` DPR-invariant). The scaling is linear across font sizes, so it is not Android 14+ non-linear font scaling either.

## Fix

Detect the OS font scale with a probe element (`offsetHeight` of a `100px`/`line-height:1` box reflects the font scaling but not devicePixelRatio or the `<html>` `scale(1/dpr)` transform, so it isolates it) and divide it out of the **glyph-size lever only**: `--text-scale-factor` feeds `font-size` and nothing else, so dividing it corrects glyph size while leaving `--total-scale-factor` — and thus positions — aligned with the canvas. At font scale 1.0 the probe returns 1.0, so the override is skipped and there is no change/regression. PDF-only; EPUB is unaffected because its text and overlay scale together.

## Verification

Built with `--features devtools` and driven over CDP on a physical Xiaomi 13 (WebView 148, `settings put system font_scale 1.5`). Rendering the transparent text layer visible (red) over the canvas confirms the glyphs land exactly on the baked-in text; a multi-line selection then tracks the text with no margin bleed or vertical offset. At font scale 1.0 the fix is a no-op and rendering is unchanged.

An earlier revision of this PR divided `--total-scale-factor` instead, which also shrank the text-layer positions and left a residual mismatch at higher font scales; this revision corrects that by dividing `--text-scale-factor` alone.

> Follow-up: readest needs a submodule pointer bump to pick this up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
