### PR TITLE
feat(paginator): expose scrollLocked via a getter

### DIFF
--- a/paginator.js
+++ b/paginator.js
@@ -1979,6 +1979,9 @@ export class Paginator extends HTMLElement {
     set containerPosition(newVal) {
         this.#container[this.scrollProp] = newVal
     }
+    get scrollLocked() {
+        return this.#scrollLocked
+    }
     set scrollLocked(value) {
         this.#scrollLocked = value
     }


### PR DESCRIPTION
## Summary

`renderer.scrollLocked` was write-only. The host (readest) sets it to lock scrolling while the Instant Highlight still-hold is engaged, and the paginator's own native swipe already bows out on `#scrollLocked`. But app-side swipe handlers that replace the native swipe — specifically readest's captured slide/curl page-turn pipeline, which sets `no-swipe` and drives the turn from a touch interceptor — had no way to read the lock back, so they kept turning the page during an instant-highlight drag.

This adds the matching getter so external swipe handlers can honor the same lock the native swipe does.

## Changes

- `paginator.js`: add `get scrollLocked()` alongside the existing setter.

## Companion

Paired with the readest app PR that gates its captured-turn interceptor on `renderer.scrollLocked`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)