### PR TITLE
fix: writable containerPosition in scroll mode + pdf linkService getAnchorUrl

### DIFF
--- a/fixed-layout.js
+++ b/fixed-layout.js
@@ -1593,7 +1593,17 @@ export class FixedLayout extends HTMLElement {
         return this.#spreads?.length ?? 0
     }
     get containerPosition() {
-        return 0
+        // In scroll mode the element itself scrolls (see atEnd/start/viewSize,
+        // which all read scrollTop). Paginated fixed layout pages via spreads and
+        // has no meaningful scroll offset, so keep returning 0 there.
+        return this.#scrollMode ? this.scrollTop : 0
+    }
+    set containerPosition(newVal) {
+        // Mirror the paginator's read/write containerPosition contract so relative
+        // scroll consumers (auto scroll, middle-click autoscroll) work on scrolled
+        // fixed-layout books (PDF / CBZ / fixed EPUB) instead of throwing on a
+        // getter-only property (READEST-11). No-op when paginated.
+        if (this.#scrollMode) this.scrollTop = newVal
     }
     get sideProp() {
         return this.#scrollMode ? 'height' : 'width'

--- a/pdf.js
+++ b/pdf.js
@@ -275,6 +275,10 @@ const render = async (page, doc, zoom, pageColors) => {
     const linkService = {
         goToDestination: () => {},
         getDestinationHash: dest => JSON.stringify(dest),
+        // pdf.js AnnotationLayer calls getAnchorUrl for named-action / GoTo link
+        // annotations; without it the render rejects with "getAnchorUrl is not a
+        // function" (READEST-2M). Match pdf.js SimpleLinkService, which returns ''.
+        getAnchorUrl: () => '',
         addLinkAttributes: (link, url) => link.href = url,
     }
     await new pdfjsLib.AnnotationLayer({ page, viewport, div, linkService }).render({


### PR DESCRIPTION
Two small fixes backing Readest Sentry crash fixes (readest/readest submodule bump).

## `fixed-layout`: writable `containerPosition` in scroll mode (READEST-11)
`FixedLayout.containerPosition` was a getter that always returned `0` with no setter, even though fixed layout supports scroll mode (PDF / CBZ / fixed-layout EPUB scrolled reading). Consumers that drive relative scrolling through the paginator's read/write `containerPosition` contract (Readest Auto Scroll and middle-click autoscroll) do `renderer.containerPosition += delta` and crashed on the getter-only property. Now read/write the element's `scrollTop` in scroll mode (mirrors the paginator); no-op when paginated.

## `pdf`: add `getAnchorUrl` to the annotation `linkService` (READEST-2M)
The `linkService` passed to `pdfjsLib.AnnotationLayer` only implemented `goToDestination` / `getDestinationHash` / `addLinkAttributes`. PDFs with named-action or GoTo link annotations make the annotation layer call `linkService.getAnchorUrl`, which rejected the render with "getAnchorUrl is not a function". Add it returning `''`, matching pdf.js `SimpleLinkService`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)