### PR TITLE
fix(epub): decode reserved characters in resolved hrefs

### DIFF
--- a/epub.js
+++ b/epub.js
@@ -92,16 +92,28 @@ const childGetter = (doc, ns) => {
     }
 }
 
+// Zip entry names are raw, so a resolved href has to be fully decoded to match
+// one. `decodeURI()` can't do it: by spec it preserves the reserved set
+// (`; / ? : @ & = + $ , #`), leaving an entry named `a&b.html` unreachable
+// behind its manifest href `a%26b.html`. Decode as a component instead, keeping
+// only `/` and `#` encoded, which would otherwise turn into a path or fragment
+// separator. Malformed escapes (a bare `%` in a name) decode to themselves.
+const decodeURIPath = path => {
+    try {
+        return decodeURIComponent(path.replace(/%(2f|23)/gi, '%25$1'))
+    } catch {
+        return path
+    }
+}
+
 const resolveURL = (url, relativeTo) => {
     try {
-        // replace %2c in the url with a comma, this might be introduced by calibre
-        url = url.replace(/%2c/gi, ',').replace(/%3a/gi, ':')
-        if (relativeTo.includes(':') && !relativeTo.startsWith('OEBPS')) return new URL(url, relativeTo)
+        if (isExternal(relativeTo)) return new URL(url, relativeTo)
         // the base needs to be a valid URL, so set a base URL and then remove it
         const root = 'https://invalid.invalid/'
         const obj = new URL(url, root + relativeTo)
         obj.search = ''
-        return decodeURI(obj.href.replace(root, ''))
+        return decodeURIPath(obj.href.replace(root, ''))
     } catch(e) {
         console.warn(e)
         return url


### PR DESCRIPTION
## Problem

Zip entry names are raw, so a resolved href has to be fully decoded to match one. `resolveURL()` decoded with `decodeURI()`, which **by spec preserves the reserved set** (`; / ? : @ & = + $ , #`) - it only undoes what `encodeURI()` would have escaped.

A chapter stored in the zip as `a&b.html` is referenced from the manifest as `href="a%26b.html"`. That href stayed encoded and never matched the entry.

The failure is silent: the zip loader returns `null` for an unknown entry name, and `loadReplaced()` turns null text into a null section, so the chapter renders as a **blank, zero-length page** instead of raising an error.

The TOC still navigates to the correct index, because the TOC `src` is resolved through the same `resolveURL`. Manifest and TOC agree with each other while both disagree with the zip, so only the content comes up empty.

This has now been hit three times: `%2c` and `%3a` were each hand-patched earlier with a pre-decode `url.replace(/%2c/gi, ',')` workaround, before `%26` surfaced in readest/readest#5097.

## Fix

Decode as a component instead, keeping only `/` and `#` encoded so they are not mistaken for a path or fragment separator. This subsumes the per-character workaround.

Decoding now happens **after** resolution, which is the correct order. The old workaround ran before `new URL()` and could turn `a%3ab.html` into `a:b.html`, where the leading `a:` was then misread as a URL scheme - which is why the absolute-base check carried a magic `!relativeTo.startsWith('OEBPS')` prefix guard. That check is now `isExternal(relativeTo)`, the real scheme test already defined in this file, so a colon resolves correctly under any book root rather than only `OEBPS/`.

## Verification

Driving the reproduction EPUB from readest/readest#5097 through the real `EPUB` class:

| | Section [1] |
| --- | --- |
| before | `id="OEBPS/a%26b.html"`, **0 bytes**, no heading |
| after | `id="OEBPS/a&b.html"`, **18990 bytes**, `"Chapter 2: A&B"` |

Regression tests land in the readest app (which is where the vitest suite lives) and cover the reported `&` chapter, its TOC entry, a `:` in the book root, and the remaining reserved characters that failed the same way. `eslint epub.js` is clean.

Fixes readest/readest#5097

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## What happens to the old `%2c` / `%3a` workaround

Ran the old and new `resolveURL` side by side over the cases that workaround existed for.

**`%2c` behavior is preserved exactly.** `ch%2c1.html` still resolves to `OEBPS/ch,1.html`, and identically across `OEBPS/` / `Text/` / `OPS/` / root-level OPFs, uppercase `%2C`, commas in a fragment, commas in a stripped query, and the double-encoded `a%252cb.html` -> `a%2cb.html`.

**`%3a` behavior changes, because the old workaround was itself broken:**

```
"ch%3a1.html" @ "OEBPS/content.opf"
   old: ch:1.html          <- OEBPS/ prefix silently dropped
   new: OEBPS/ch:1.html
```

Pre-replacing `%3a` with `:` before `new URL()` produced `ch:1.html`, which the URL parser reads as **scheme `ch:`**, so the base was discarded along with the directory prefix. The result never matched the zip entry `OEBPS/ch:1.html`, so a colon chapter stayed blank anyway. The workaround only appeared to work when the OPF sat at the zip root. Resolving first and decoding after removes the misparse, which is also what lets the `OEBPS` prefix guard go away.

Two other diffs, both repairs in the same direction:

- `img.png` @ `Text/a:b.html`: old threw and returned the href unresolved, new returns `Text/img.png`.
- `100%.html` (a bare `%` in a filename): old threw, because `decodeURI` rejects the malformed escape, new returns `OEBPS/100%.html`.

The only genuine behavior change is on an **external base** (`https://.../content.opf`), where `%2c` now stays percent-encoded rather than becoming `,`. That branch is unreachable for EPUB, since `relativeTo` is always a zip path (`opfPath` or `item.href`), and keeping `%2c` encoded in an HTTP URL is correct regardless.

The colon case is covered by the reserved-characters regression test, which asserts the section id is `OEBPS/a:b.html` and failed before this change.


## Provenance of the removed lines, and why #346 does not regress

Traced each removed line back through the readest submodule bumps (the fork's history is a single squashed patch commit, so `git log -S` on this repo does not show them):

| removed line | came from | ticket |
| --- | --- | --- |
| `!relativeTo.startsWith('OEBPS')` guard | readest#349 | readest#346, "Pictures in book (ePub) can not be displayed" |
| `url.replace(/%2c/, ',')` | readest#796, "hack to decode incorrectly encoded url in href" | none (empty body, no linked issue) |
| `%3a` + the `/gi` flags | readest#1379, "css: handle inline image height" | none (drive-by in an unrelated bump) |

Only **readest#346** has a real ticket, so that is the one to protect.

Its mechanism: the book carried a **raw, unencoded `:`** in a chapter path (the `%3a` decode did not exist yet in #349, so `decodeURI` could never have produced a colon). That chapter path becomes the base its own images resolve against, and the base was scheme-tested with `relativeTo.includes(':')`, which sent it down the `new URL(url, relativeTo)` branch. `OEBPS/Text/ch:1.xhtml` is not a valid absolute URL, so `new URL()` threw, the `catch` returned the href unresolved, and no image in that chapter loaded. #349 patched it by exempting bases starting with `OEBPS`, which left books under any other root (`OPS/`, `Text/`, ...) still broken.

`isExternal(relativeTo)` is the real scheme test, so that base is no longer mistaken for a URL and the branch is never taken.

**Verified both directions.** The regression test builds a book with `href="Text/ch:1.html"` and resolves images from it, under an `OEBPS/` root and a `Text/` root:

- against the **pre-fix** `epub.js`: the `OEBPS/` case passes (the #349 guard) and the `Text/` case fails
- against the **fixed** `epub.js`: both pass

So #346 keeps working and additionally starts working for books that are not rooted at `OEBPS/`.


### Verified against the real #346 book

The reproduction book for readest#346 (`大奉打更人.epub`, 971 zip entries, 935 spine sections) turns out to name every file with raw, unencoded `:` and `*` characters, exactly the shape reconstructed above:

```
OEBPS/Text/::*****:**:******::******::*:::::***:::*::*:::*:*:*:.xhtml
OEBPS/Images/:***::::**:::*:****:*****:*:::*:::::::*::*:**::**::.jpg
```

with the OPF referencing them unencoded: `href="Text/::::*:::*::**:*:...xhtml"`. So a chapter path carries a `:`, and it is that path which every image inside the chapter resolves against.

Resolving every `<img src>` in the book's image-bearing chapters and checking each result against the actual zip entry list:

| `resolveURL` version | images resolving to a real zip entry |
| --- | --- |
| pre-#349 upstream (the original bug) | **0 / 8** - reproduces "Pictures in book can not be displayed" |
| current `main` (OEBPS guard + `%2c`/`%3a` hack) | **8 / 8** |
| this PR | **8 / 8** |

The first row confirms the check actually detects the #346 failure, so the third row is meaningful: this PR resolves every image exactly as `main` does, and reads the same 935 spine sections. #346 does not regress.
