### PR TITLE
fix(pdf): bound iOS WebContent memory when rendering and zooming PDFs

### DIFF
--- a/pdf.js
+++ b/pdf.js
@@ -189,37 +189,40 @@ const render = async (page, doc, zoom, pageColors) => {
         activeRenderTasks.delete(doc)
     }
 
-    // Clamp the device pixel ratio the page is rasterised at so the canvas
-    // bitmap and its WebKit backing layer stay within the iOS content-process
-    // memory budget (readest #5118). The `1 / renderDpr` fit transform matches,
-    // so the displayed page box is unchanged — only the raster resolution drops.
+    // Rasterise the page bitmap over-sampled (clamped for the iOS content-process
+    // memory budget, see getRenderDpr / readest #5118) but lay the whole DOM out
+    // at the true display size. The <canvas> element natively downscales its
+    // bitmap to its CSS box, so the raster stays crisp WITHOUT scaling the
+    // document. Scaling the document with `transform` promotes the whole page to
+    // one over-sized GPU IOSurface that OOM-kills the iOS WebContent process on
+    // zoom; scaling it with `zoom` throws off getBoundingClientRect, misplacing
+    // text selection and the annotation toolbar. Neither is used: the text and
+    // annotation layers live in real display coordinates.
     const renderDpr = getRenderDpr(page, zoom)
-    const scale = zoom * renderDpr
-    doc.documentElement.style.transform = `scale(${1 / renderDpr})`
-    doc.documentElement.style.transformOrigin = 'top left'
-    doc.documentElement.style.setProperty('--total-scale-factor', scale)
+    const renderScale = zoom * renderDpr
+    doc.documentElement.style.setProperty('--total-scale-factor', zoom)
     doc.documentElement.style.setProperty('--user-unit', '1')
     doc.documentElement.style.setProperty('--scale-round-x', '1px')
     doc.documentElement.style.setProperty('--scale-round-y', '1px')
-    const viewport = page.getViewport({ scale })
+    // The bitmap viewport is over-sampled; the display viewport drives the CSS
+    // box, the text layer and the annotation layer (all in display coordinates).
+    const renderViewport = page.getViewport({ scale: renderScale })
+    const displayViewport = page.getViewport({ scale: zoom })
 
     // the canvas must be in the `PDFDocument`'s `ownerDocument`
     // (`globalThis.document` by default); that's where the fonts are loaded
     const canvas = document.createElement('canvas')
-    canvas.height = viewport.height
-    canvas.width = viewport.width
-    // `canvas.width`/`canvas.height` are the bitmap size and must be integers,
-    // so the fractional `viewport.{width,height}` (= pageSizeCss * renderDpr) is
-    // truncated. The iframe content is displayed scaled by `1 / renderDpr` (see
-    // the `documentElement` transform above), so a truncated bitmap renders up to
-    // ~1 device pixel narrower than the page box,
-    // leaving a one-pixel white seam at the spine of a two-page spread (#4587).
-    // Pin an explicit CSS size to the un-truncated viewport dimensions so the
-    // bitmap scales to fill the page box exactly.
-    canvas.style.width = `${viewport.width}px`
-    canvas.style.height = `${viewport.height}px`
+    canvas.height = renderViewport.height
+    canvas.width = renderViewport.width
+    // The CSS box is the un-truncated display size, so the (integer-truncated)
+    // over-sampled bitmap is scaled by the browser to fill the page box exactly.
+    // Pinning the box to the display viewport (rather than letting the truncated
+    // bitmap drive layout) also keeps the left page flush to the spine of a
+    // two-page spread instead of exposing a one-pixel white seam (#4587).
+    canvas.style.width = `${displayViewport.width}px`
+    canvas.style.height = `${displayViewport.height}px`
     const canvasContext = canvas.getContext('2d')
-    const renderTask = page.render({ canvasContext, viewport, pageColors })
+    const renderTask = page.render({ canvasContext, viewport: renderViewport, pageColors })
     activeRenderTasks.set(doc, renderTask)
 
     try {
@@ -262,7 +265,7 @@ const render = async (page, doc, zoom, pageColors) => {
     container.replaceChildren()
     const textLayer = new pdfjsLib.TextLayer({
         textContentSource: await page.streamTextContent(),
-        container, viewport,
+        container, viewport: displayViewport,
     })
     await textLayer.render()
 
@@ -310,7 +313,7 @@ const render = async (page, doc, zoom, pageColors) => {
         getAnchorUrl: () => '',
         addLinkAttributes: (link, url) => link.href = url,
     }
-    await new pdfjsLib.AnnotationLayer({ page, viewport, div, linkService }).render({
+    await new pdfjsLib.AnnotationLayer({ page, viewport: displayViewport, div, linkService }).render({
         annotations: await page.getAnnotations(),
     })
 }

--- a/pdf.js
+++ b/pdf.js
@@ -151,6 +151,30 @@ const setupPanningEvents = (doc) => {
     container.style.cursor = 'grab'
 }
 
+// iOS kills the WKWebView content process when it exceeds a per-process memory
+// high-water limit (~2 GB). A device crash log for readest #5118 shows the
+// foreground WebContent process reaching 2.1 GB while paging a PDF, right before
+// the reader "closed". Both a page's canvas bitmap and its WebKit backing layer
+// are allocated at the render scale, so their memory grows with the SQUARE of the
+// device pixel ratio. Phones report dpr 3, which is the tipping factor; desktop
+// WebKit has no such per-process ceiling, which is why the crash is iOS-only.
+// Rendering at 2x instead of 3x is still retina-sharp but uses ~2.25x less memory
+// per page (the crisp, selectable text layer is a separate DOM layer, unaffected).
+const MAX_RENDER_DPR = 2
+// Hard ceiling on a single page's bitmap area (~3.1 Mpx ≈ 12.6 MB) so a large
+// tablet page can't blow the budget even after the dpr clamp.
+const MAX_CANVAS_PIXELS = 2048 * 1536
+
+// The device pixel ratio to rasterise this page at: the real dpr clamped by both
+// MAX_RENDER_DPR and the per-canvas pixel budget, never below 1 (CSS resolution).
+const getRenderDpr = (page, zoom) => {
+    let dpr = Math.min(devicePixelRatio || 1, MAX_RENDER_DPR)
+    const { width, height } = page.getViewport({ scale: zoom || 1 })
+    const area = width * height * dpr * dpr
+    if (area > MAX_CANVAS_PIXELS) dpr *= Math.sqrt(MAX_CANVAS_PIXELS / area)
+    return Math.max(1, dpr)
+}
+
 const render = async (page, doc, zoom, pageColors) => {
     if (!doc) return
 
@@ -165,8 +189,13 @@ const render = async (page, doc, zoom, pageColors) => {
         activeRenderTasks.delete(doc)
     }
 
-    const scale = zoom * devicePixelRatio
-    doc.documentElement.style.transform = `scale(${1 / devicePixelRatio})`
+    // Clamp the device pixel ratio the page is rasterised at so the canvas
+    // bitmap and its WebKit backing layer stay within the iOS content-process
+    // memory budget (readest #5118). The `1 / renderDpr` fit transform matches,
+    // so the displayed page box is unchanged — only the raster resolution drops.
+    const renderDpr = getRenderDpr(page, zoom)
+    const scale = zoom * renderDpr
+    doc.documentElement.style.transform = `scale(${1 / renderDpr})`
     doc.documentElement.style.transformOrigin = 'top left'
     doc.documentElement.style.setProperty('--total-scale-factor', scale)
     doc.documentElement.style.setProperty('--user-unit', '1')
@@ -180,10 +209,10 @@ const render = async (page, doc, zoom, pageColors) => {
     canvas.height = viewport.height
     canvas.width = viewport.width
     // `canvas.width`/`canvas.height` are the bitmap size and must be integers,
-    // so the fractional `viewport.{width,height}` (= pageSizeCss *
-    // devicePixelRatio) is truncated. The iframe content is displayed scaled by
-    // `1 / devicePixelRatio` (see the `documentElement` transform above), so a
-    // truncated bitmap renders up to ~1 device pixel narrower than the page box,
+    // so the fractional `viewport.{width,height}` (= pageSizeCss * renderDpr) is
+    // truncated. The iframe content is displayed scaled by `1 / renderDpr` (see
+    // the `documentElement` transform above), so a truncated bitmap renders up to
+    // ~1 device pixel narrower than the page box,
     // leaving a one-pixel white seam at the spine of a two-page spread (#4587).
     // Pin an explicit CSS size to the un-truncated viewport dimensions so the
     // bitmap scales to fill the page box exactly.


### PR DESCRIPTION
## Problem

On iOS, reading a PDF crashes the WKWebView content process: the page reloads after turning a few pages, or immediately when zooming in past ~150%. The app itself does not crash, only the WebContent process. A device crash log (iOS 18.7.9) shows `com.apple.WebKit.WebContent` reaching **2.10 GB** with reason `highwater` (the per-process memory limit). macOS WebKit has no such per-process ceiling, so it never triggers there; the iOS web build hits the same limit.

`render()` rasterised each page at `zoom * devicePixelRatio` (dpr 3 on phones) and fitted the device-resolution canvas back into its CSS box with `transform: scale(1/dpr)`. Two problems, both iOS-only:

1. The canvas bitmap and pdf.js image decode grow with the **square of the device pixel ratio** (dpr 3 is ~2.25x heavier than needed).
2. A `transform: scale()` is **visual only — it does not shrink layout size**, so the canvas stayed laid out at the full device-oversampled resolution and WebKit backed that whole area with one GPU IOSurface (times the device pixel ratio). Zooming grew it quadratically to ~2 GB.

## Fix

- `getRenderDpr(page, zoom)` clamps the rasterisation dpr to `MAX_RENDER_DPR` (2, still retina) and further so the bitmap area stays within `MAX_CANVAS_PIXELS`.
- Render the whole DOM at the **true display size** and over-sample only the `<canvas>` **bitmap**, which the canvas element natively downscales into its CSS box. No document `transform`/`zoom`: the only GPU surface is the clamped bitmap, and the text/annotation layers stay in real display coordinates (so `getBoundingClientRect` — hence text selection and the annotation toolbar — is correct).

The displayed page box is unchanged; only the raster resolution drops slightly on high-dpr screens. The #4587 spread-seam behaviour is preserved (the canvas CSS box is the un-truncated display viewport).

For readest/readest#5118.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
